### PR TITLE
Close idle connections in http2 client

### DIFF
--- a/packages/connect/lib/src/http2/connection.dart
+++ b/packages/connect/lib/src/http2/connection.dart
@@ -59,9 +59,13 @@ final class _Http2ClientTransportConnectionManager
     Uri uri,
   ) async {
     final socket = await _connectSocket(uri);
-    return Http2ClientTransportConnection(
-      http2.ClientTransportConnection.viaSocket(socket),
-    );
+    final connection = http2.ClientTransportConnection.viaSocket(socket);
+    connection.onActiveStateChanged = (active) {
+      if (!active) {
+        connection.finish().ignore();
+      }
+    };
+    return Http2ClientTransportConnection(connection);
   }
 
   Future<io.Socket> _connectSocket(Uri uri) async {


### PR DESCRIPTION
Close idle connections in http2 client. This will be revamped next week when we implement proper H/2 connection management. We will have extensive tests for that. For now, this will ensure to close any idle connections and each connection is only used for one request.

This was reported [here](https://bufbuild.slack.com/archives/CRZ680FUH/p1738156266273419)