### PR TITLE
Fix connectrpc version in example and conformance project

### DIFF
--- a/examples/eliza/pubspec.yaml
+++ b/examples/eliza/pubspec.yaml
@@ -2,7 +2,7 @@ name: eliza
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -31,12 +31,11 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  connectrpc: 0.1.0
-
+  connectrpc:
+    path: ../../packages/connect
 
 dev_dependencies:
   flutter_test:
@@ -54,7 +53,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/conformance/pubspec.yaml
+++ b/packages/conformance/pubspec.yaml
@@ -14,7 +14,8 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 dependencies:
   protobuf: ^3.1.0
-  connectrpc: ^0.1.0
+  connectrpc:
+    path: ../connect
   archive: ^3.6.1
   path: ^1.9.0
   args: ^2.5.0


### PR DESCRIPTION
Fix connectrpc version in example and conformance project. This is causing an issue with plain dart builds, for example when building the plugin to upload to BSR