### PR TITLE
Add `User-Agent` header

### DIFF
--- a/packages/connect/lib/src/connect/header.dart
+++ b/packages/connect/lib/src/connect/header.dart
@@ -17,6 +17,7 @@ import '../codec.dart';
 import '../compression.dart';
 import '../headers.dart';
 import '../spec.dart';
+import '../version.dart';
 import 'version.dart';
 
 const headerContentType = "content-type";
@@ -27,6 +28,7 @@ const headerUnaryEncoding = "content-encoding";
 const headerStreamEncoding = "connect-content-encoding";
 const headerUnaryAcceptEncoding = "accept-encoding";
 const headerStreamAcceptEncoding = "connect-accept-encoding";
+const headerUserAgent = "user-agent";
 
 Headers requestHeader(
   Codec codec,
@@ -47,7 +49,9 @@ Headers requestHeader(
   header[headerContentType] = streamType == StreamType.unary
       ? 'application/${codec.name}'
       : 'application/connect+${codec.name}';
-  // TODO: User agent headers.
+  if (!header.contains(headerUserAgent)) {
+    header[headerUserAgent] = 'connect-dart/$version';
+  }
   if (sendCompression != null) {
     header[streamType == StreamType.unary
         ? headerUnaryEncoding

--- a/packages/connect/lib/src/grpc/request_header.dart
+++ b/packages/connect/lib/src/grpc/request_header.dart
@@ -16,6 +16,7 @@ import '../abort.dart';
 import '../codec.dart';
 import '../compression.dart';
 import '../headers.dart';
+import '../version.dart';
 import 'headers.dart';
 
 const contentTypePrefix = "application/grpc";
@@ -38,7 +39,9 @@ Headers requestHeader(
   // The gRPC-HTTP2 specification requires this - it flushes out proxies that
   // don't support HTTP trailers.
   header["Te"] = "trailers";
-  // TODO: User agent headers.
+  if (!header.contains(headerUserAgent)) {
+    header[headerUserAgent] = 'connect-dart/$version';
+  }
   if (sendCompression != null) {
     header[headerEncoding] = sendCompression.name;
   }

--- a/packages/connect/lib/src/grpc_web/request_header.dart
+++ b/packages/connect/lib/src/grpc_web/request_header.dart
@@ -17,6 +17,7 @@ import '../codec.dart';
 import '../compression.dart';
 import '../grpc/headers.dart';
 import '../headers.dart';
+import '../version.dart';
 
 const contentTypePrefix = "application/grpc-web";
 
@@ -45,7 +46,9 @@ Headers requestHeader(
     header[headerTimeout] =
         '${deadline.difference(DateTime.now()).inMilliseconds}m';
   }
-  // TODO: User agent headers.
+  if (!header.contains(headerUserAgent)) {
+    header[headerUserAgent] = 'connect-dart/$version';
+  }
   if (sendCompression != null) {
     header[headerEncoding] = sendCompression.name;
   }

--- a/packages/connect/lib/src/version.dart
+++ b/packages/connect/lib/src/version.dart
@@ -12,11 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const headerContentType = "content-type";
-const headerGrpcStatus = "grpc-status";
-const headerGrpcMessage = "grpc-message";
-const headerTimeout = "grpc-timeout";
-const headerEncoding = "grpc-encoding";
-const headerAcceptEncoding = "grpc-accept-encoding";
-const headerStatusDetailsBin = "grpc-status-details-bin";
-const headerUserAgent = "user-agent";
+/// Version of the connect package.
+const version = '0.2.1';

--- a/packages/connect/lib/src/web.dart
+++ b/packages/connect/lib/src/web.dart
@@ -29,6 +29,10 @@ HttpClient createHttpClient() {
   return (creq) async {
     final reqHeader = web.Headers();
     for (final header in creq.header.entries) {
+      // Skip the default user-agent header.
+      if (header.name == 'user-agent' && header.value.startsWith('connect-dart/')) {
+        continue;
+      }
       reqHeader.append(header.name, header.value);
     }
     Uint8List? body;


### PR DESCRIPTION
Add `User-Agent` header to all transports. This is similar to other clients. We skip the header for web clients.