### PR TITLE
Release `0.3.0`

### DIFF
--- a/packages/conformance/pubspec.yaml
+++ b/packages/conformance/pubspec.yaml
@@ -2,7 +2,7 @@ name: conformance
 description: >-
   Conformance tests for connect
 
-version: 0.2.1
+version: 0.3.0
 homepage: https://connectrpc.com
 documentation: https://connectrpc.com/docs
 publish_to: none

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0
+
+- Add `Http2ClientTransport` to manage HTTP/2 connections using PING frames for keep alive. This resulted
+  in a breaking change in `createHttpClient` of `package:connectrpc/http2.dart`. `SecurityContext` is no longer
+  accepted, and instead replaced by a new `transport` option. The default transport (`Http2ClientTransport`)
+  accepts a `SecurityContext`.
+- Send a default `User-Agent` header on non web platforms.
+
 ## 0.2.1
 
 - Fix the connectrpc path in example and internal package.

--- a/packages/connect/lib/src/version.dart
+++ b/packages/connect/lib/src/version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// Version of the connect package.
-const version = '0.2.1';
+const version = '0.3.0';

--- a/packages/connect/pubspec.yaml
+++ b/packages/connect/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Implementation of the Connect protocol for Dart. Simple, reliable, interoperable.
   Protobuf RPC that works
 
-version: 0.2.1
+version: 0.3.0
 homepage: https://connectrpc.com
 documentation: https://connectrpc.com/docs
 repository: https://github.com/connectrpc/connect-dart


### PR DESCRIPTION
## What's Changed
* Add `User-Agent` header by @srikrsna-buf in https://github.com/connectrpc/connect-dart/pull/8
### 🚨 Breaking Changes 🚨 
* https://github.com/connectrpc/connect-dart/pull/10 Introduces a way to manage HTTP/2 connections. To support this, the `context` option of `createHttpClient` in `package:connectrpc/http2.dart` was removed. It is now accepted by the transport provided by the  `transport` option:
```diff
- createHttpClient(context: context);
+ createHttpClient(
+   transport: Http2ClientTransport(
+     context: context,
+   ),
+ );
```

**Full Changelog**: https://github.com/connectrpc/connect-dart/compare/v0.2.1...v0.3.0