### PR TITLE
Bump version of protobuf to 4.0.0

### DIFF
--- a/packages/conformance/pubspec.yaml
+++ b/packages/conformance/pubspec.yaml
@@ -2,7 +2,7 @@ name: conformance
 description: >-
   Conformance tests for connect
 
-version: 0.3.0
+version: 0.4.0
 homepage: https://connectrpc.com
 documentation: https://connectrpc.com/docs
 publish_to: none
@@ -13,7 +13,7 @@ executables:
 environment:
   sdk: ">=3.3.0 <4.0.0"
 dependencies:
-  protobuf: ^3.1.0
+  protobuf: ^4.0.0
   connectrpc:
     path: ../connect
   archive: ^3.6.1

--- a/packages/connect/pubspec.yaml
+++ b/packages/connect/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Implementation of the Connect protocol for Dart. Simple, reliable, interoperable.
   Protobuf RPC that works
 
-version: 0.3.0
+version: 0.4.0
 homepage: https://connectrpc.com
 documentation: https://connectrpc.com/docs
 repository: https://github.com/connectrpc/connect-dart
@@ -14,7 +14,7 @@ executables:
 environment:
   sdk: ">=3.3.0 <4.0.0"
 dependencies:
-  protobuf: ^3.1.0
+  protobuf: ^4.0.0
   path: ^1.9.0
   http2: ^2.3.0
   fixnum: ^1.1.1


### PR DESCRIPTION
Using Protobuf version 4.0.0: This update enables compatibility with the latest Protobuf version; otherwise, the application will encounter a compile-time error.