### PR TITLE
Update protobuf version constraint

### DIFF
--- a/example/eliza/lib/gen/eliza.pb.dart
+++ b/example/eliza/lib/gen/eliza.pb.dart
@@ -16,7 +16,7 @@
 //  Generated code. Do not modify.
 //  source: eliza.proto
 //
-// @dart = 2.12
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -27,6 +27,8 @@ import 'dart:async' as $async;
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class SayRequest extends $pb.GeneratedMessage {
   factory SayRequest({
@@ -85,7 +87,7 @@ class SayRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.bool hasSentence() => $_has(0);
   @$pb.TagNumber(1)
-  void clearSentence() => clearField(1);
+  void clearSentence() => $_clearField(1);
 }
 
 class SayResponse extends $pb.GeneratedMessage {
@@ -146,7 +148,7 @@ class SayResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.bool hasSentence() => $_has(0);
   @$pb.TagNumber(1)
-  void clearSentence() => clearField(1);
+  void clearSentence() => $_clearField(1);
 }
 
 class ElizaServiceApi {

--- a/example/eliza/lib/gen/eliza.pbenum.dart
+++ b/example/eliza/lib/gen/eliza.pbenum.dart
@@ -16,7 +16,7 @@
 //  Generated code. Do not modify.
 //  source: eliza.proto
 //
-// @dart = 2.12
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/example/eliza/lib/gen/eliza.pbjson.dart
+++ b/example/eliza/lib/gen/eliza.pbjson.dart
@@ -16,7 +16,7 @@
 //  Generated code. Do not modify.
 //  source: eliza.proto
 //
-// @dart = 2.12
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/example/eliza/lib/gen/eliza.pbserver.dart
+++ b/example/eliza/lib/gen/eliza.pbserver.dart
@@ -16,7 +16,7 @@
 //  Generated code. Do not modify.
 //  source: eliza.proto
 //
-// @dart = 2.12
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names

--- a/example/web/pubspec.yaml
+++ b/example/web/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   web: ^1.0.0
   connectrpc:
     path: ../../packages/connect
-  protobuf: ^3.0.0
+  protobuf: '>=3.1.0 <5.0.0'
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/packages/conformance/pubspec.yaml
+++ b/packages/conformance/pubspec.yaml
@@ -13,7 +13,7 @@ executables:
 environment:
   sdk: ">=3.3.0 <4.0.0"
 dependencies:
-  protobuf: ^3.1.0
+  protobuf: '>=3.1.0 <5.0.0'
   connectrpc:
     path: ../connect
   archive: ^3.6.1

--- a/packages/connect/pubspec.yaml
+++ b/packages/connect/pubspec.yaml
@@ -14,7 +14,7 @@ executables:
 environment:
   sdk: ">=3.3.0 <4.0.0"
 dependencies:
-  protobuf: ^3.1.0
+  protobuf: '>=3.1.0 <5.0.0'
   path: ^1.9.0
   http2: ^2.3.0
   fixnum: ^1.1.1


### PR DESCRIPTION
A new version of protobuf was released, there were no breaking changes. We can support both version.

Closes #16 and #15 