### PR TITLE
Remove content-length when using web clients

### DIFF
--- a/packages/connect/lib/src/web.dart
+++ b/packages/connect/lib/src/web.dart
@@ -69,12 +69,14 @@ HttpClient createHttpClient() {
       }
       // Browsers and other fetch environments decompress the response,
       // but retain the original content-encoding and content-length headers.
+      // This causes issues when we validate the response body length against
+      // the content-length header.
+      // We remove it here, and instead rely on parsing the response body to
+      // determine issues with with the response.
       //
       // https://github.com/wintercg/fetch/issues/23
-      if (resHeader.contains('content-encoding')) {
-        resHeader.remove('content-encoding');
-        resHeader.remove('content-length');
-      }
+      resHeader.remove('content-encoding');
+      resHeader.remove('content-length');
       return HttpResponse(
         res.status,
         resHeader,


### PR DESCRIPTION
This PR ensures we always remove the content-length & content-encoding headers when using fetch-based HTTP clients.

It was discovered that when performing length checks in the protocol code, the length supplied by these clients was often incorrect because the browser has already performed decompression on the response. By removing these headers when using the web client, we forgo length checks and instead rely on the protocol parsing to validate any malformed responses.

Fixes #13.