### PR TITLE
Improve `splitEnvelope`

### DIFF
--- a/packages/connect/lib/src/protocol/envelope.dart
+++ b/packages/connect/lib/src/protocol/envelope.dart
@@ -56,62 +56,68 @@ extension SplitEnvelope on Stream<Uint8List> {
   /// - if the stream ended before an enveloped message fully arrived,
   /// - or if the stream ended with extraneous data.
   Stream<EnvelopedMessage> splitEnvelope() async* {
-    var buffer = Uint8List(0);
-    await for (final chunk in this) {
-      buffer = _append(buffer, chunk);
-      while (true) {
-        final header = _peekHeader(buffer);
-        if (header == null) {
-          break;
-        }
-        EnvelopedMessage? env;
-        (env, buffer) = _shiftEnvelope(buffer, header);
+    final header = Uint8List(5);
+    var headerLen = 0;
+    var dataLen = 0;
+    EnvelopedMessage? env;
+    await for (var chunk in this) {
+      while (chunk.isNotEmpty) {
+        // We are waiting for the next heeader
         if (env == null) {
+          final needLen = 5 - headerLen;
+          // If we have to read more to get the header.
+          if (chunk.length < needLen) {
+            header.setAll(headerLen, chunk);
+            headerLen += chunk.length;
+            break;
+          }
+          header.setAll(
+            headerLen,
+            Uint8List.sublistView(chunk, 0, needLen),
+          );
+          headerLen = 5;
+          final (:flags, :length) = _readHeader(header);
+          env = EnvelopedMessage(
+            flags,
+            Uint8List(length),
+          );
+          // Reset data length and update chunk to reflect remaining data.
+          dataLen = 0;
+          chunk = Uint8List.sublistView(chunk, needLen);
+        }
+        // We are reading the envelope.
+        final needLen = env.data.length - dataLen;
+        // If we have to read more to complete the envelope.
+        if (chunk.length < needLen) {
+          env.data.setAll(dataLen, chunk);
+          dataLen += chunk.length;
           break;
         }
+        // We can complete the envelope.
+        env.data.setAll(
+          dataLen,
+          Uint8List.sublistView(chunk, 0, needLen),
+        );
         yield env;
+        // Reset the header and chunk and continue processing.
+        env = null;
+        headerLen = 0;
+        chunk = Uint8List.sublistView(chunk, needLen);
       }
     }
-    if (buffer.lengthInBytes > 0) {
-      final header = _peekHeader(buffer);
+    if (headerLen > 0) {
       var message = "protocol error: incomplete envelope";
-      if (header != null) {
+      if (headerLen == 5) {
+        final (flags: _, :length) = _readHeader(header);
         message =
-            'protocol error: promised ${header.length} bytes in enveloped message, got ${buffer.lengthInBytes - 5} bytes';
+            'protocol error: promised $length bytes in enveloped message, got $dataLen bytes';
       }
       throw ConnectException(Code.invalidArgument, message);
     }
   }
 
-  static Uint8List _append(Uint8List buffer, Uint8List other) {
-    final result = Uint8List(buffer.length + other.length);
-    result.setAll(0, buffer);
-    result.setAll(buffer.length, other);
-    return result;
-  }
-
-  static ({int length, int flags})? _peekHeader(Uint8List buffer) {
-    if (buffer.lengthInBytes < 5) {
-      return null;
-    }
+  static ({int length, int flags}) _readHeader(Uint8List buffer) {
     final data = ByteData.sublistView(buffer);
     return (length: data.getUint32(1), flags: data.getUint8(0));
-  }
-
-  /// Returns the enveloped message if complete and the remaining buffer
-  static (EnvelopedMessage?, Uint8List) _shiftEnvelope(
-    Uint8List buffer,
-    ({int length, int flags}) header,
-  ) {
-    if (buffer.lengthInBytes < 5 + header.length) {
-      return (null, buffer);
-    }
-    return (
-      EnvelopedMessage(
-        header.flags,
-        Uint8List.sublistView(buffer, 5, 5 + header.length),
-      ),
-      Uint8List.sublistView(buffer, 5 + header.length)
-    );
   }
 }

--- a/packages/connect/test/envelope_test.dart
+++ b/packages/connect/test/envelope_test.dart
@@ -1,0 +1,149 @@
+import "dart:typed_data";
+
+import "package:connectrpc/connect.dart";
+import "package:connectrpc/src/protocol/envelope.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SplitEnvelope", () {
+    group("one message", () {
+      // 100 bytes
+      final env = EnvelopedMessage(0, Uint8List(95));
+      final envBytes = encodeEnvelope(env.flags, env.data);
+      final expected = emitsInOrder([
+        allOf(HasFlags(env), HasData(env)),
+        emitsDone,
+      ]);
+      test("One chunk", () {
+        expect(
+          Stream.fromIterable([envBytes]).splitEnvelope(),
+          expected,
+        );
+      });
+      test("split at header", () {
+        expect(
+          Stream.fromIterable(envBytes.split(5)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("split before header", () {
+        expect(
+          Stream.fromIterable(envBytes.split(2)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("split mid data", () {
+        expect(
+          Stream.fromIterable(envBytes.split(50)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("empty chunk", () {
+        expect(
+          Stream<Uint8List>.fromIterable([]).splitEnvelope(),
+          emitsInOrder([emitsDone]),
+        );
+      });
+      test("Invalid header", () {
+        expect(
+          Stream.fromIterable([envBytes.sublist(0, 2)]).splitEnvelope(),
+          emitsInOrder([emitsError(isA<ConnectException>())]),
+        );
+      });
+      test("Invalid data", () {
+        expect(
+          Stream.fromIterable([envBytes.sublist(0, 50)]).splitEnvelope(),
+          emitsInOrder([emitsError(isA<ConnectException>())]),
+        );
+      });
+    });
+    group("two messages", () {
+      // 100 bytes
+      final env = EnvelopedMessage(0, Uint8List(95));
+      final envBytes = encodeEnvelope(env.flags, env.data);
+      // 200
+      final streamBytes = Uint8List.fromList(envBytes + envBytes);
+      final expected = emitsInOrder([
+        allOf(HasFlags(env), HasData(env)),
+        allOf(HasFlags(env), HasData(env)),
+        emitsDone,
+      ]);
+      test("One each", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(100)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("Both together", () {
+        expect(
+          Stream.fromIterable([streamBytes]).splitEnvelope(),
+          expected,
+        );
+      });
+      test("At first header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(5)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("Before first header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(2)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("After first header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(6)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("At second header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(105)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("Before second header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(102)).splitEnvelope(),
+          expected,
+        );
+      });
+      test("After second header", () {
+        expect(
+          Stream.fromIterable(streamBytes.split(106)).splitEnvelope(),
+          expected,
+        );
+      });
+    });
+  });
+}
+
+class HasFlags extends CustomMatcher {
+  HasFlags(
+    EnvelopedMessage env,
+  ) : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
+
+  @override
+  Object? featureValueOf(actual) {
+    return (actual as EnvelopedMessage).flags;
+  }
+}
+
+class HasData extends CustomMatcher {
+  HasData(
+    EnvelopedMessage env,
+  ) : super("EnvelopeMessage with data that is", "data", equals(env.data));
+
+  @override
+  Object? featureValueOf(actual) {
+    return (actual as EnvelopedMessage).data;
+  }
+}
+
+extension on Uint8List {
+  List<Uint8List> split(int index) {
+    return [sublist(0, index), sublist(index)];
+  }
+}

--- a/packages/connect/test/envelope_test.dart
+++ b/packages/connect/test/envelope_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2024-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import "dart:typed_data";
 
 import "package:connectrpc/connect.dart";


### PR DESCRIPTION
By preallocating the header bytes and allocating the message bytes once per message we avoid extra allocations of the previous implementation. A similar change was recently implemented at https://github.com/connectrpc/connect-es/pull/1530