### PR TITLE
fix: use package:protobuf imports for wellknown types

### DIFF
--- a/packages/connect/bin/src/plugin.dart
+++ b/packages/connect/bin/src/plugin.dart
@@ -180,7 +180,56 @@ extension on GeneratedFile {
     p(["  );"]);
   }
 
+  // Wellknown types that should use package:protobuf imports
+  static const _wellknownTypes = {
+    '.google.protobuf.Any',
+    '.google.protobuf.Duration',
+    '.google.protobuf.Empty',
+    '.google.protobuf.FieldMask',
+    '.google.protobuf.Struct',
+    '.google.protobuf.Value',
+    '.google.protobuf.ListValue',
+    '.google.protobuf.NullValue',
+    '.google.protobuf.Timestamp',
+    '.google.protobuf.DoubleValue',
+    '.google.protobuf.FloatValue',
+    '.google.protobuf.Int64Value',
+    '.google.protobuf.UInt64Value',
+    '.google.protobuf.Int32Value',
+    '.google.protobuf.UInt32Value',
+    '.google.protobuf.BoolValue',
+    '.google.protobuf.StringValue',
+    '.google.protobuf.BytesValue',
+  };
+
+  // Map wellknown type names to their file names in package:protobuf
+  static String? _wellknownTypeFile(String typeName) {
+    if (!typeName.startsWith('.google.protobuf.')) return null;
+    final shortName = typeName.split('.').last;
+    // Map type name to file name
+    if (shortName == 'Any') return 'any';
+    if (shortName == 'Duration') return 'duration';
+    if (shortName == 'Empty') return 'empty';
+    if (shortName == 'FieldMask') return 'field_mask';
+    if (shortName == 'Struct' || shortName == 'Value' ||
+        shortName == 'ListValue' || shortName == 'NullValue') return 'struct';
+    if (shortName == 'Timestamp') return 'timestamp';
+    if (shortName.endsWith('Value')) return 'wrappers'; // All wrapper types
+    return null;
+  }
+
   DartIdentifier importMsg(String typeName) {
+    // Check if it's a wellknown type - use package:protobuf import if enabled
+    if (schema.wellknownFromPackage && _wellknownTypes.contains(typeName)) {
+      final fileName = _wellknownTypeFile(typeName);
+      if (fileName != null) {
+        return DartLibrary(
+          'package:protobuf/well_known_types/google/protobuf/$fileName.pb.dart',
+          'wkt_$fileName',
+        ).import(typeName.split('.').last);
+      }
+    }
+
     for (final file in schema.file.values) {
       if (!typeName.startsWith(".${file.package}")) {
         continue;

--- a/packages/connect/bin/src/run.dart
+++ b/packages/connect/bin/src/run.dart
@@ -32,12 +32,18 @@ final class Schema {
   /// Whether to print empty files or not.
   final bool keepEmptyFiles;
 
+  /// Whether to import wellknown types from package:protobuf instead of
+  /// generating relative imports. Defaults to true to match the behavior
+  /// of protocolbuffers/dart plugin.
+  final bool wellknownFromPackage;
+
   factory Schema.fromProto(CodeGeneratorRequest proto) {
     final file = <String, FileDescriptorProto>{};
     for (final protoFile in proto.protoFile) {
       file[protoFile.name] = protoFile;
     }
     var keepEmptyFiles = false;
+    var wellknownFromPackage = true;
     if (proto.parameter.isNotEmpty) {
       for (final raw in proto.parameter.split(",")) {
         final parts = raw.split('=');
@@ -50,14 +56,20 @@ final class Schema {
               throw "invalid plugin option 'keep_empty_files' must be a bool, got $value";
             }
             keepEmptyFiles = val;
+          case "wellknown_from_package":
+            final val = value.isEmpty ? true : bool.tryParse(value);
+            if (val == null) {
+              throw "invalid plugin option 'wellknown_from_package' must be a bool, got $value";
+            }
+            wellknownFromPackage = val;
           default:
             throw "Unsupported plugin option $raw";
         }
       }
     }
-    return Schema._(proto.sourceFileDescriptors, file, proto, keepEmptyFiles);
+    return Schema._(proto.sourceFileDescriptors, file, proto, keepEmptyFiles, wellknownFromPackage);
   }
-  Schema._(this.files, this.file, this.proto, this.keepEmptyFiles);
+  Schema._(this.files, this.file, this.proto, this.keepEmptyFiles, this.wellknownFromPackage);
 }
 
 /// Runs the plugin by parsing the [input] into a [CodeGeneratorRequest]

--- a/packages/connect/pubspec.yaml
+++ b/packages/connect/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.6.0
 resolution: workspace
 dependencies:
-  protobuf: ">=3.1.0 <5.0.0"
+  protobuf: ">=4.0.0 <7.0.0"
   path: ^1.9.0
   http2: ^2.3.0
   fixnum: ^1.1.1


### PR DESCRIPTION
Fixes #33

## Problem

When using connect-dart with `protocolbuffers/dart` plugin, wellknown types (`google.protobuf.*`) are provided by `package:protobuf/well_known_types/` rather than being generated locally.

Previously, connect-dart always generated relative imports for these types, causing type mismatches at runtime.

## Solution

Add a new plugin option `wellknown_from_package` (default: `true`) that controls how wellknown types are imported:

- `wellknown_from_package=true` (default): imports from `package:protobuf/well_known_types/`
- `wellknown_from_package=false`: generates relative imports (for custom setups)

Also updates protobuf constraint to `>=4.0.0 <7.0.0` for protobuf 6.x support.

## Usage

```yaml
# buf.gen.yaml - default behavior (package imports)
- local: path/to/protoc-gen-connect-dart
  out: lib/gen

# Or explicitly disable for custom setups
- local: path/to/protoc-gen-connect-dart
  out: lib/gen
  opt: wellknown_from_package=false
```

## Supported wellknown types

Any, Duration, Empty, FieldMask, Struct, Value, ListValue, NullValue, Timestamp, and all wrapper types.