### PR TITLE
Add editions support

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Support generating code from `.proto` files using editions (proto2 through edition 2024).
+
 ## 1.0.0
 
 - First stable release of Connect for Dart!

--- a/packages/connect/bin/src/run.dart
+++ b/packages/connect/bin/src/run.dart
@@ -73,7 +73,10 @@ Future<void> run(
   final res = CodeGeneratorResponse();
   // Adding here instead of setting directly lets us avoid a direct dependency on fixnum package.
   res.supportedFeatures = res.supportedFeatures +
-      CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL.value;
+      CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL.value +
+      CodeGeneratorResponse_Feature.FEATURE_SUPPORTS_EDITIONS.value;
+  res.minimumEdition = Edition.EDITION_PROTO2.value;
+  res.maximumEdition = Edition.EDITION_2024.value;
   try {
     final files = generate(Schema.fromProto(
       CodeGeneratorRequest.fromBuffer(reqBytes),

--- a/packages/connect/test/plugin/golden/edition/edition.connect.client
+++ b/packages/connect/test/plugin/golden/edition/edition.connect.client
@@ -1,0 +1,27 @@
+//
+//  Generated code. Do not modify.
+//  source: edition/edition.proto
+//
+
+import "package:connectrpc/connect.dart" as connect;
+import "edition.pb.dart" as editionedition;
+import "edition.connect.spec.dart" as specs;
+
+extension type EditionServiceClient (connect.Transport _transport) {
+  Future<editionedition.Msg> unary(
+    editionedition.Msg input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.EditionService.unary,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+}

--- a/packages/connect/test/plugin/golden/edition/edition.connect.spec
+++ b/packages/connect/test/plugin/golden/edition/edition.connect.spec
@@ -1,0 +1,19 @@
+//
+//  Generated code. Do not modify.
+//  source: edition/edition.proto
+//
+
+import "package:connectrpc/connect.dart" as connect;
+import "edition.pb.dart" as editionedition;
+
+abstract final class EditionService {
+  /// Fully-qualified name of the EditionService service.
+  static const name = 'edition.EditionService';
+
+  static const unary = connect.Spec(
+    '/$name/Unary',
+    connect.StreamType.unary,
+    editionedition.Msg.new,
+    editionedition.Msg.new,
+  );
+}

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -100,7 +100,6 @@ void main() async {
       response.supportedFeatures &
           CodeGeneratorResponse_Feature.FEATURE_SUPPORTS_EDITIONS.value,
       isNot(0),
-      reason: 'plugin must advertise FEATURE_SUPPORTS_EDITIONS',
     );
     expect(response.minimumEdition, Edition.EDITION_PROTO2.value);
     expect(response.maximumEdition, Edition.EDITION_2024.value);

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -88,6 +88,14 @@ void main() async {
       ),
     );
   });
+  test('generates edition 2024 file', () async {
+    expect(
+      await runPlugin(image, "edition/edition.proto"),
+      matchGenerated(
+        ['edition/edition.connect.client', 'edition/edition.connect.spec'],
+      ),
+    );
+  });
 }
 
 Future<CodeGeneratorResponse> runPlugin(

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -89,12 +89,21 @@ void main() async {
     );
   });
   test('generates edition 2024 file', () async {
+    final response = await runPlugin(image, "edition/edition.proto");
     expect(
-      await runPlugin(image, "edition/edition.proto"),
+      response,
       matchGenerated(
         ['edition/edition.connect.client', 'edition/edition.connect.spec'],
       ),
     );
+    expect(
+      response.supportedFeatures &
+          CodeGeneratorResponse_Feature.FEATURE_SUPPORTS_EDITIONS.value,
+      isNot(0),
+      reason: 'plugin must advertise FEATURE_SUPPORTS_EDITIONS',
+    );
+    expect(response.minimumEdition, Edition.EDITION_PROTO2.value);
+    expect(response.maximumEdition, Edition.EDITION_2024.value);
   });
 }
 

--- a/packages/connect/test/plugin/proto/edition/edition.proto
+++ b/packages/connect/test/plugin/proto/edition/edition.proto
@@ -1,0 +1,23 @@
+// Copyright 2024-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2024";
+
+package edition;
+
+message Msg {}
+
+service EditionService {
+  rpc Unary(Msg) returns (Msg);
+}

--- a/packages/tools/bin/buf.dart
+++ b/packages/tools/bin/buf.dart
@@ -17,7 +17,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-const version = "1.53.0";
+const version = "1.68.2";
 const cacheDir = ".tmp/bin";
 
 Future<int> main(List<String> args) async {


### PR DESCRIPTION
Fix https://github.com/connectrpc/connect-dart/issues/37 (I noticed during triage that this issue seems straightforward to fix so I had a quick look)

This allows generating code for proto files using editions. Editions are a protobuf feature, so I don't expect any impact on this connect lib.

This consists mostly of marking editions as supported in the `CodeGeneratorResponse`. I also added a test to compile an edition file and make sure the flags are set correctly, and updated buf.

I tested editions locally by running the eliza example after converting the proto file to editions: everything works correctly with the changed proposed by this PR.