### PR TITLE
Bump dart version to 3.7.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -42,23 +42,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "lint; Dart 3.6.0; PKGS: packages/conformance, packages/connect; `dart run tools:buf generate`, `dart run tools:license_header .`, `dart format .`, `dart analyze`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
+    name: "lint; Dart 3.7.0; PKGS: packages/conformance, packages/connect; `dart run tools:buf generate`, `dart run tools:license_header .`, `dart format .`, `dart analyze`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/conformance-packages/connect;commands:command_0-command_1-command_2-analyze-command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/conformance-packages/connect;commands:command_0-command_1-command_2-analyze-command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/conformance-packages/connect
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/conformance-packages/connect
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -113,23 +113,23 @@ jobs:
         if: "always() && steps.packages_connect_pub_upgrade.conclusion == 'success'"
         working-directory: packages/connect
   job_003:
-    name: "lint; Dart 3.6.0; PKG: packages/tools; `dart format .`, `dart run tools:license_header .`, `dart analyze`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
+    name: "lint; Dart 3.7.0; PKG: packages/tools; `dart format .`, `dart run tools:license_header .`, `dart analyze`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/tools;commands:command_2-command_1-analyze-command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/tools;commands:command_2-command_1-analyze-command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/tools
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/tools
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -268,23 +268,23 @@ jobs:
         if: "always() && steps.packages_tools_pub_upgrade.conclusion == 'success'"
         working-directory: packages/tools
   job_006:
-    name: "test; Dart 3.6.0; PKG: packages/conformance; `dart test`"
+    name: "test; Dart 3.7.0; PKG: packages/conformance; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/conformance;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/conformance;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/conformance
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/conformance
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -304,23 +304,23 @@ jobs:
       - job_004
       - job_005
   job_007:
-    name: "test; Dart 3.6.0; PKG: packages/connect; `dart test -p chrome`"
+    name: "test; Dart 3.7.0; PKG: packages/connect; `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -340,23 +340,23 @@ jobs:
       - job_004
       - job_005
   job_008:
-    name: "test; Dart 3.6.0; PKG: packages/connect; `dart test -p vm`"
+    name: "test; Dart 3.7.0; PKG: packages/connect; `dart test -p vm`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect;commands:test_2"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect;commands:test_2"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -484,23 +484,23 @@ jobs:
       - job_004
       - job_005
   job_012:
-    name: "license; Dart 3.6.0; PKG: packages/connect; `dart run tools:license_header ../..`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
+    name: "license; Dart 3.7.0; PKG: packages/connect; `dart run tools:license_header ../..`, `[[ -z $(git status --porcelain | tee >(cat 1>&2)) ]]`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect;commands:command_4-command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect;commands:command_4-command_3"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0;packages:packages/connect
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0;packages:packages/connect
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: "3.6.0"
+          sdk: "3.7.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/example/eliza/lib/main.dart
+++ b/example/eliza/lib/main.dart
@@ -71,9 +71,9 @@ class _ChatPageState extends State<ChatPage> {
 
   void send(String sentence) async {
     addMessage(sentence, true);
-    final response = await ElizaServiceClient(widget.transport).say(
-      SayRequest(sentence: sentence),
-    );
+    final response = await ElizaServiceClient(
+      widget.transport,
+    ).say(SayRequest(sentence: sentence));
     addMessage(response.sentence, false);
   }
 
@@ -103,7 +103,7 @@ class _ChatPageState extends State<ChatPage> {
                                     color: Colors.grey,
                                     fontWeight: FontWeight.w600,
                                   ),
-                                )
+                                ),
                               ],
                             ),
                             Row(
@@ -114,7 +114,7 @@ class _ChatPageState extends State<ChatPage> {
                                   textAlign: TextAlign.left,
                                 ),
                               ],
-                            )
+                            ),
                           ] else ...[
                             const Row(
                               children: [
@@ -136,10 +136,10 @@ class _ChatPageState extends State<ChatPage> {
                                 ),
                                 const Spacer(),
                               ],
-                            )
-                          ]
+                            ),
+                          ],
                         ],
-                      )
+                      ),
                   ],
                 ),
               ),
@@ -167,9 +167,9 @@ class _ChatPageState extends State<ChatPage> {
                       'Send',
                       style: TextStyle(color: Colors.blue),
                     ),
-                  )
+                  ),
                 ],
-              )
+              ),
             ],
           ),
         ),

--- a/example/eliza/pubspec.yaml
+++ b/example/eliza/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/example/web/pubspec.yaml
+++ b/example/web/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 # repository: https://github.com/my_org/my_repo
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 publish_to: none
 
 # Add regular dependencies here.

--- a/example/web/web/main.dart
+++ b/example/web/web/main.dart
@@ -51,12 +51,13 @@ Future<String> prompt() {
   web.document.querySelector("#root")?.append(input);
   input.focus();
   final completer = Completer<String>();
-  input.onkeyup = (web.KeyboardEvent ev) {
-    if (ev.key == "Enter" && input.value.isNotEmpty) {
-      input.remove();
-      input.onkeyup = null;
-      completer.complete(input.value);
-    }
-  }.toJS;
+  input.onkeyup =
+      (web.KeyboardEvent ev) {
+        if (ev.key == "Enter" && input.value.isNotEmpty) {
+          input.remove();
+          input.onkeyup = null;
+          completer.complete(input.value);
+        }
+      }.toJS;
   return completer.future;
 }

--- a/packages/conformance/bin/pipe.dart
+++ b/packages/conformance/bin/pipe.dart
@@ -22,7 +22,8 @@ void main(List<String> args) async {
   final flags = parser.parse(args);
   final port = int.parse(flags.option('port') ?? '');
   final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
-  await Future.wait(
-    [stdin.pipe(socket), socket.cast<List<int>>().pipe(stdout)],
-  );
+  await Future.wait([
+    stdin.pipe(socket),
+    socket.cast<List<int>>().pipe(stdout),
+  ]);
 }

--- a/packages/conformance/lib/src/gen/connectrpc/conformance/v1/service.connect.client.dart
+++ b/packages/conformance/lib/src/gen/connectrpc/conformance/v1/service.connect.client.dart
@@ -195,7 +195,7 @@ extension type ConformanceServiceClient(connect.Transport _transport) {
   /// Implementations should use an HTTP GET when invoking this endpoint and
   /// leverage query parameters to send data.
   Future<connectrpcconformancev1service.IdempotentUnaryResponse>
-  idempotentUnary(
+      idempotentUnary(
     connectrpcconformancev1service.IdempotentUnaryRequest input, {
     connect.Headers? headers,
     connect.AbortSignal? signal,

--- a/packages/conformance/lib/src/gen/connectrpc/conformance/v1/service.connect.client.dart
+++ b/packages/conformance/lib/src/gen/connectrpc/conformance/v1/service.connect.client.dart
@@ -195,7 +195,7 @@ extension type ConformanceServiceClient(connect.Transport _transport) {
   /// Implementations should use an HTTP GET when invoking this endpoint and
   /// leverage query parameters to send data.
   Future<connectrpcconformancev1service.IdempotentUnaryResponse>
-      idempotentUnary(
+  idempotentUnary(
     connectrpcconformancev1service.IdempotentUnaryRequest input, {
     connect.Headers? headers,
     connect.AbortSignal? signal,

--- a/packages/conformance/lib/src/invoke.dart
+++ b/packages/conformance/lib/src/invoke.dart
@@ -65,23 +65,24 @@ Future<ClientResponseResult> unary(
     if (cancelTiming.afterCloseSendMs >= 0) {
       wait(cancelTiming.afterCloseSendMs).then(signal.cancel).ignore();
     }
-    final uResFuture = !idempotent
-        ? client.unary(
-            uReq as UnaryRequest,
-            headers: reqHeader,
-            signal: signal,
-            onHeader: (header) => resHeaders = convertToProtoHeaders(header),
-            onTrailer: (trailer) =>
-                resTrailers = convertToProtoHeaders(trailer),
-          )
-        : client.idempotentUnary(
-            uReq as IdempotentUnaryRequest,
-            headers: reqHeader,
-            signal: signal,
-            onHeader: (header) => resHeaders = convertToProtoHeaders(header),
-            onTrailer: (trailer) =>
-                resTrailers = convertToProtoHeaders(trailer),
-          );
+    final uResFuture =
+        !idempotent
+            ? client.unary(
+              uReq as UnaryRequest,
+              headers: reqHeader,
+              signal: signal,
+              onHeader: (header) => resHeaders = convertToProtoHeaders(header),
+              onTrailer:
+                  (trailer) => resTrailers = convertToProtoHeaders(trailer),
+            )
+            : client.idempotentUnary(
+              uReq as IdempotentUnaryRequest,
+              headers: reqHeader,
+              signal: signal,
+              onHeader: (header) => resHeaders = convertToProtoHeaders(header),
+              onTrailer:
+                  (trailer) => resTrailers = convertToProtoHeaders(trailer),
+            );
     payloads.add(switch (await uResFuture) {
       UnaryResponse uRes => uRes.payload,
       IdempotentUnaryResponse uRes => uRes.payload,

--- a/packages/conformance/lib/src/invoke.dart
+++ b/packages/conformance/lib/src/invoke.dart
@@ -65,24 +65,23 @@ Future<ClientResponseResult> unary(
     if (cancelTiming.afterCloseSendMs >= 0) {
       wait(cancelTiming.afterCloseSendMs).then(signal.cancel).ignore();
     }
-    final uResFuture =
-        !idempotent
-            ? client.unary(
-              uReq as UnaryRequest,
-              headers: reqHeader,
-              signal: signal,
-              onHeader: (header) => resHeaders = convertToProtoHeaders(header),
-              onTrailer:
-                  (trailer) => resTrailers = convertToProtoHeaders(trailer),
-            )
-            : client.idempotentUnary(
-              uReq as IdempotentUnaryRequest,
-              headers: reqHeader,
-              signal: signal,
-              onHeader: (header) => resHeaders = convertToProtoHeaders(header),
-              onTrailer:
-                  (trailer) => resTrailers = convertToProtoHeaders(trailer),
-            );
+    final uResFuture = !idempotent
+        ? client.unary(
+            uReq as UnaryRequest,
+            headers: reqHeader,
+            signal: signal,
+            onHeader: (header) => resHeaders = convertToProtoHeaders(header),
+            onTrailer: (trailer) =>
+                resTrailers = convertToProtoHeaders(trailer),
+          )
+        : client.idempotentUnary(
+            uReq as IdempotentUnaryRequest,
+            headers: reqHeader,
+            signal: signal,
+            onHeader: (header) => resHeaders = convertToProtoHeaders(header),
+            onTrailer: (trailer) =>
+                resTrailers = convertToProtoHeaders(trailer),
+          );
     payloads.add(switch (await uResFuture) {
       UnaryResponse uRes => uRes.payload,
       IdempotentUnaryResponse uRes => uRes.payload,

--- a/packages/conformance/lib/src/protocol.dart
+++ b/packages/conformance/lib/src/protocol.dart
@@ -75,16 +75,17 @@ class CancellationTiming {
   final int afterCloseSendMs;
   final int afterNumResponses;
 
-  factory CancellationTiming.forRequest(ClientCompatRequest req) =>
-      switch (req.cancel.whichCancelTiming()) {
-        ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
-          CancellationTiming._(beforeCloseSend: true),
-        ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
-          CancellationTiming._(afterCloseSendMs: req.cancel.afterCloseSendMs),
-        ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
-          CancellationTiming._(afterNumResponses: req.cancel.afterNumResponses),
-        _ => CancellationTiming._(),
-      };
+  factory CancellationTiming.forRequest(ClientCompatRequest req) => switch (req
+      .cancel
+      .whichCancelTiming()) {
+    ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
+      CancellationTiming._(beforeCloseSend: true),
+    ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
+      CancellationTiming._(afterCloseSendMs: req.cancel.afterCloseSendMs),
+    ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
+      CancellationTiming._(afterNumResponses: req.cancel.afterNumResponses),
+    _ => CancellationTiming._(),
+  };
 
   CancellationTiming._({
     this.beforeCloseSend = false,

--- a/packages/conformance/lib/src/protocol.dart
+++ b/packages/conformance/lib/src/protocol.dart
@@ -19,10 +19,7 @@ import 'gen/connectrpc/conformance/v1/config.pb.dart';
 import 'gen/connectrpc/conformance/v1/service.pb.dart';
 import 'gen/google/protobuf/any.pb.dart';
 
-void addProtoHeaders(
-  connect.Headers headers,
-  List<Header> protoHeaders,
-) {
+void addProtoHeaders(connect.Headers headers, List<Header> protoHeaders) {
   for (final header in protoHeaders) {
     for (final value in header.value) {
       headers.add(header.name, value);
@@ -50,10 +47,7 @@ Error? convertToProtoError(connect.ConnectException? err) {
   final details = List<Any>.empty(growable: true);
   for (final detail in err.details) {
     details.add(
-      Any(
-        typeUrl: "type.googleapis.com/${detail.type}",
-        value: detail.value,
-      ),
+      Any(typeUrl: "type.googleapis.com/${detail.type}", value: detail.value),
     );
   }
   return Error(
@@ -81,22 +75,17 @@ class CancellationTiming {
   final int afterCloseSendMs;
   final int afterNumResponses;
 
-  factory CancellationTiming.forRequest(ClientCompatRequest req) =>
-      switch (req.cancel.whichCancelTiming()) {
-        ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
-          CancellationTiming._(
-            beforeCloseSend: true,
-          ),
-        ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
-          CancellationTiming._(
-            afterCloseSendMs: req.cancel.afterCloseSendMs,
-          ),
-        ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
-          CancellationTiming._(
-            afterNumResponses: req.cancel.afterNumResponses,
-          ),
-        _ => CancellationTiming._(),
-      };
+  factory CancellationTiming.forRequest(ClientCompatRequest req) => switch (req
+      .cancel
+      .whichCancelTiming()) {
+    ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
+      CancellationTiming._(beforeCloseSend: true),
+    ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
+      CancellationTiming._(afterCloseSendMs: req.cancel.afterCloseSendMs),
+    ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
+      CancellationTiming._(afterNumResponses: req.cancel.afterNumResponses),
+    _ => CancellationTiming._(),
+  };
 
   CancellationTiming._({
     this.beforeCloseSend = false,

--- a/packages/conformance/lib/src/protocol.dart
+++ b/packages/conformance/lib/src/protocol.dart
@@ -75,17 +75,16 @@ class CancellationTiming {
   final int afterCloseSendMs;
   final int afterNumResponses;
 
-  factory CancellationTiming.forRequest(ClientCompatRequest req) => switch (req
-      .cancel
-      .whichCancelTiming()) {
-    ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
-      CancellationTiming._(beforeCloseSend: true),
-    ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
-      CancellationTiming._(afterCloseSendMs: req.cancel.afterCloseSendMs),
-    ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
-      CancellationTiming._(afterNumResponses: req.cancel.afterNumResponses),
-    _ => CancellationTiming._(),
-  };
+  factory CancellationTiming.forRequest(ClientCompatRequest req) =>
+      switch (req.cancel.whichCancelTiming()) {
+        ClientCompatRequest_Cancel_CancelTiming.beforeCloseSend =>
+          CancellationTiming._(beforeCloseSend: true),
+        ClientCompatRequest_Cancel_CancelTiming.afterCloseSendMs =>
+          CancellationTiming._(afterCloseSendMs: req.cancel.afterCloseSendMs),
+        ClientCompatRequest_Cancel_CancelTiming.afterNumResponses =>
+          CancellationTiming._(afterNumResponses: req.cancel.afterNumResponses),
+        _ => CancellationTiming._(),
+      };
 
   CancellationTiming._({
     this.beforeCloseSend = false,

--- a/packages/conformance/lib/src/runner.dart
+++ b/packages/conformance/lib/src/runner.dart
@@ -41,8 +41,9 @@ final class ConformanceRunner {
   late final String cacheDir;
 
   ConformanceRunner({String? version, String? cacheDir})
-      : version = version ?? defaultVersion {
-    this.cacheDir = cacheDir ??
+    : version = version ?? defaultVersion {
+    this.cacheDir =
+        cacheDir ??
         Platform.environment['CONFORMANCE_CACHE'] ??
         Directory.systemTemp.absolute.path;
   }
@@ -99,9 +100,10 @@ final class ConformanceRunner {
 
   /// Returns the path to the binary.
   Future<String> get _binary async {
-    final bin = Platform.operatingSystem == "windows"
-        ? "connectconformance.exe"
-        : "connectconformance";
+    final bin =
+        Platform.operatingSystem == "windows"
+            ? "connectconformance.exe"
+            : "connectconformance";
     final binPath = p.join(cacheDir, bin);
     // Check to see if the binary is already at path and matches the version.
     if (File(binPath).existsSync()) {
@@ -147,9 +149,10 @@ Future<void> _extractBinary(String path, String to) async {
   final archiveFile = InputFileStream(path);
   final binName =
       path.endsWith(".zip") ? "connectconformance.exe" : "connectconformance";
-  final archive = path.endsWith(".zip")
-      ? ZipDecoder().decodeBuffer(archiveFile)
-      : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
+  final archive =
+      path.endsWith(".zip")
+          ? ZipDecoder().decodeBuffer(archiveFile)
+          : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
   final file = archive.files.singleWhere(
     (f) => f.name == binName,
     orElse: () {

--- a/packages/conformance/lib/src/runner.dart
+++ b/packages/conformance/lib/src/runner.dart
@@ -40,11 +40,10 @@ final class ConformanceRunner {
   /// Defaults to the system's temporary directory..
   late final String cacheDir;
 
-  ConformanceRunner({
-    String? version,
-    String? cacheDir,
-  }) : version = version ?? defaultVersion {
-    this.cacheDir = cacheDir ??
+  ConformanceRunner({String? version, String? cacheDir})
+    : version = version ?? defaultVersion {
+    this.cacheDir =
+        cacheDir ??
         Platform.environment['CONFORMANCE_CACHE'] ??
         Directory.systemTemp.absolute.path;
   }
@@ -101,9 +100,10 @@ final class ConformanceRunner {
 
   /// Returns the path to the binary.
   Future<String> get _binary async {
-    final bin = Platform.operatingSystem == "windows"
-        ? "connectconformance.exe"
-        : "connectconformance";
+    final bin =
+        Platform.operatingSystem == "windows"
+            ? "connectconformance.exe"
+            : "connectconformance";
     final binPath = p.join(cacheDir, bin);
     // Check to see if the binary is already at path and matches the version.
     if (File(binPath).existsSync()) {
@@ -149,12 +149,16 @@ Future<void> _extractBinary(String path, String to) async {
   final archiveFile = InputFileStream(path);
   final binName =
       path.endsWith(".zip") ? "connectconformance.exe" : "connectconformance";
-  final archive = path.endsWith(".zip")
-      ? ZipDecoder().decodeBuffer(archiveFile)
-      : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
-  final file = archive.files.singleWhere((f) => f.name == binName, orElse: () {
-    throw "Failed to extract connectconformance.exe";
-  });
+  final archive =
+      path.endsWith(".zip")
+          ? ZipDecoder().decodeBuffer(archiveFile)
+          : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
+  final file = archive.files.singleWhere(
+    (f) => f.name == binName,
+    orElse: () {
+      throw "Failed to extract connectconformance.exe";
+    },
+  );
   final out = OutputFileStream(to);
   file.writeContent(out);
   await out.close();
@@ -186,10 +190,7 @@ StreamTransformer<Uint8List, Uint8List> _encodeEnvelope() {
   return StreamTransformer.fromHandlers(
     handleData: (data, sink) {
       final sizeBytes = Uint8List(4);
-      ByteData.sublistView(sizeBytes).setUint32(
-        0,
-        data.lengthInBytes,
-      );
+      ByteData.sublistView(sizeBytes).setUint32(0, data.lengthInBytes);
       sink.add(sizeBytes);
       sink.add(data);
     },

--- a/packages/conformance/lib/src/runner.dart
+++ b/packages/conformance/lib/src/runner.dart
@@ -41,9 +41,8 @@ final class ConformanceRunner {
   late final String cacheDir;
 
   ConformanceRunner({String? version, String? cacheDir})
-    : version = version ?? defaultVersion {
-    this.cacheDir =
-        cacheDir ??
+      : version = version ?? defaultVersion {
+    this.cacheDir = cacheDir ??
         Platform.environment['CONFORMANCE_CACHE'] ??
         Directory.systemTemp.absolute.path;
   }
@@ -100,10 +99,9 @@ final class ConformanceRunner {
 
   /// Returns the path to the binary.
   Future<String> get _binary async {
-    final bin =
-        Platform.operatingSystem == "windows"
-            ? "connectconformance.exe"
-            : "connectconformance";
+    final bin = Platform.operatingSystem == "windows"
+        ? "connectconformance.exe"
+        : "connectconformance";
     final binPath = p.join(cacheDir, bin);
     // Check to see if the binary is already at path and matches the version.
     if (File(binPath).existsSync()) {
@@ -149,10 +147,9 @@ Future<void> _extractBinary(String path, String to) async {
   final archiveFile = InputFileStream(path);
   final binName =
       path.endsWith(".zip") ? "connectconformance.exe" : "connectconformance";
-  final archive =
-      path.endsWith(".zip")
-          ? ZipDecoder().decodeBuffer(archiveFile)
-          : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
+  final archive = path.endsWith(".zip")
+      ? ZipDecoder().decodeBuffer(archiveFile)
+      : TarDecoder().decodeBytes(GZipDecoder().decodeBuffer(archiveFile));
   final file = archive.files.singleWhere(
     (f) => f.name == binName,
     orElse: () {

--- a/packages/conformance/lib/src/test_io.dart
+++ b/packages/conformance/lib/src/test_io.dart
@@ -24,33 +24,27 @@ void testClient(
   ConformanceArgs args,
   Transport Function(ClientCompatRequest req) transportFactory,
 ) {
-  test(
-    description,
-    timeout: Timeout.none,
-    () async {
-      final runner = ConformanceRunner();
-      final result = await runner.runClient(
-        args: args.toList(),
-        StreamTransformer.fromBind(
-          (requests) async* {
-            await for (final req in requests) {
-              final res = ClientCompatResponse(testName: req.testName);
-              try {
-                final result = await invoke(transportFactory(req), req);
-                res.response = result;
-              } catch (err) {
-                res.error = ClientErrorResult(message: '$err');
-              }
-              yield res;
-            }
-          },
-        ),
-      );
-      expect(
-        result,
-        equals(0),
-        reason: 'connectconformance exited with a non-zero code',
-      );
-    },
-  );
+  test(description, timeout: Timeout.none, () async {
+    final runner = ConformanceRunner();
+    final result = await runner.runClient(
+      args: args.toList(),
+      StreamTransformer.fromBind((requests) async* {
+        await for (final req in requests) {
+          final res = ClientCompatResponse(testName: req.testName);
+          try {
+            final result = await invoke(transportFactory(req), req);
+            res.response = result;
+          } catch (err) {
+            res.error = ClientErrorResult(message: '$err');
+          }
+          yield res;
+        }
+      }),
+    );
+    expect(
+      result,
+      equals(0),
+      reason: 'connectconformance exited with a non-zero code',
+    );
+  });
 }

--- a/packages/conformance/pubspec.yaml
+++ b/packages/conformance/pubspec.yaml
@@ -11,7 +11,7 @@ executables:
   pipe:
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 resolution: workspace
 dependencies:
   protobuf: ">=3.1.0 <5.0.0"

--- a/packages/conformance/test/runner_test.dart
+++ b/packages/conformance/test/runner_test.dart
@@ -19,23 +19,20 @@ import 'package:conformance/runner.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test(
-    'runner should exit with non-zero code on failed cases',
-    () async {
-      final conformance = ConformanceRunner();
-      final result = await conformance.runClient(
-        StreamTransformer.fromBind(
-          (requests) => requests.map(
-            (req) => ClientCompatResponse(testName: req.testName),
-          ),
-        ),
-        args: ConformanceArgs(
-          run: [
-            "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
-          ],
-        ).toList(),
-      );
-      expect(result, isNot(0)); // We expect this to fail.
-    },
-  );
+  test('runner should exit with non-zero code on failed cases', () async {
+    final conformance = ConformanceRunner();
+    final result = await conformance.runClient(
+      StreamTransformer.fromBind(
+        (requests) =>
+            requests.map((req) => ClientCompatResponse(testName: req.testName)),
+      ),
+      args:
+          ConformanceArgs(
+            run: [
+              "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
+            ],
+          ).toList(),
+    );
+    expect(result, isNot(0)); // We expect this to fail.
+  });
 }

--- a/packages/conformance/test/runner_test.dart
+++ b/packages/conformance/test/runner_test.dart
@@ -26,12 +26,11 @@ void main() {
         (requests) =>
             requests.map((req) => ClientCompatResponse(testName: req.testName)),
       ),
-      args:
-          ConformanceArgs(
-            run: [
-              "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
-            ],
-          ).toList(),
+      args: ConformanceArgs(
+        run: [
+          "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
+        ],
+      ).toList(),
     );
     expect(result, isNot(0)); // We expect this to fail.
   });

--- a/packages/conformance/test/runner_test.dart
+++ b/packages/conformance/test/runner_test.dart
@@ -26,11 +26,12 @@ void main() {
         (requests) =>
             requests.map((req) => ClientCompatResponse(testName: req.testName)),
       ),
-      args: ConformanceArgs(
-        run: [
-          "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
-        ],
-      ).toList(),
+      args:
+          ConformanceArgs(
+            run: [
+              "Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:true/unary/empty-definition",
+            ],
+          ).toList(),
     );
     expect(result, isNot(0)); // We expect this to fail.
   });

--- a/packages/connect/bin/src/plugin.dart
+++ b/packages/connect/bin/src/plugin.dart
@@ -55,9 +55,7 @@ extension on GeneratedFile {
     pServiceDoc(service);
     p(["abstract final class ", service.name, " {"]);
     p(["  /// Fully-qualified name of the ", service.name, " service."]);
-    p(
-      ["  static const name = '", proto.package, ".", service.name, "';"],
-    );
+    p(["  static const name = '", proto.package, ".", service.name, "';"]);
     for (final method in service.method) {
       p([]);
       pMethodDoc(service, method);
@@ -73,7 +71,7 @@ extension on GeneratedFile {
       service.name,
       "Client (",
       connect.import('Transport'),
-      " _transport) {"
+      " _transport) {",
     ]);
     var first = true;
     for (final method in service.method) {
@@ -93,10 +91,7 @@ extension on GeneratedFile {
     ]);
   }
 
-  void pMethod(
-    ServiceDescriptorProto service,
-    MethodDescriptorProto method,
-  ) {
+  void pMethod(ServiceDescriptorProto service, MethodDescriptorProto method) {
     final specsLib = DartLibrary(
       "${path.basenameWithoutExtension(proto.name)}.connect.spec.dart",
       "specs",
@@ -109,11 +104,12 @@ extension on GeneratedFile {
       method.serverStreaming ? "Stream" : "Future",
       "<",
       importMsg(method.outputType),
-      ">"
+      ">",
     ];
-    final inputType = method.clientStreaming
-        ? ["Stream", "<", importMsg(method.inputType), ">"]
-        : [importMsg(method.inputType)];
+    final inputType =
+        method.clientStreaming
+            ? ["Stream", "<", importMsg(method.inputType), ">"]
+            : [importMsg(method.inputType)];
     p(["  ", ...returnType, " ", method.localName, "("]);
     p(["    ", ...inputType, " input, {"]);
     pMethodOptions();
@@ -123,7 +119,7 @@ extension on GeneratedFile {
       connect.import("Client"),
       "(_transport).",
       method.streamType,
-      "("
+      "(",
     ]);
     p(["      ", specsLib.import(service.name), ".", method.localName, ","]);
     p(["      input,"]);
@@ -139,15 +135,12 @@ extension on GeneratedFile {
     ServiceDescriptorProto service,
     MethodDescriptorProto method,
   ) {
-    pDartDoc(
-      [
-        FileDescriptorProto().info_.byName["service"]!.tagNumber,
-        proto.service.indexOf(service),
-        ServiceDescriptorProto().info_.byName["method"]!.tagNumber,
-        service.method.indexOf(method),
-      ],
-      "  ",
-    );
+    pDartDoc([
+      FileDescriptorProto().info_.byName["service"]!.tagNumber,
+      proto.service.indexOf(service),
+      ServiceDescriptorProto().info_.byName["method"]!.tagNumber,
+      service.method.indexOf(method),
+    ], "  ");
   }
 
   void pMethodOptions() {
@@ -163,7 +156,7 @@ extension on GeneratedFile {
       method.localName,
       " = ",
       connect.import("Spec"),
-      "("
+      "(",
     ]);
     p(["    '/\$name/", method.name, "',"]);
     p(["    ", connect.import("StreamType"), ".", method.streamType, ","]);
@@ -191,9 +184,7 @@ extension on GeneratedFile {
         continue;
       }
       return DartLibrary(
-        "${path.withoutExtension(
-          path.relative(file.name, from: path.dirname(proto.name)),
-        )}.pb.dart",
+        "${path.withoutExtension(path.relative(file.name, from: path.dirname(proto.name)))}.pb.dart",
         path.withoutExtension(file.name).replaceAll("/", ""),
       ).import(typeName.split(".").last);
     }
@@ -249,17 +240,13 @@ extension on List<DescriptorProto> {
     }
     if (!typeName.contains(".")) {
       // Can only be at this level
-      return any(
-        (msg) => msg.name == typeName,
-      );
+      return any((msg) => msg.name == typeName);
     }
     // Can only be a sub message.
     final outerType = typeName.split(".").first;
     for (final msg in this) {
       if (msg.name == outerType) {
-        return msg.nestedType.hasMessage(
-          typeName.substring(outerType.length),
-        );
+        return msg.nestedType.hasMessage(typeName.substring(outerType.length));
       }
     }
     return false;

--- a/packages/connect/bin/src/plugin.dart
+++ b/packages/connect/bin/src/plugin.dart
@@ -106,9 +106,10 @@ extension on GeneratedFile {
       importMsg(method.outputType),
       ">",
     ];
-    final inputType = method.clientStreaming
-        ? ["Stream", "<", importMsg(method.inputType), ">"]
-        : [importMsg(method.inputType)];
+    final inputType =
+        method.clientStreaming
+            ? ["Stream", "<", importMsg(method.inputType), ">"]
+            : [importMsg(method.inputType)];
     p(["  ", ...returnType, " ", method.localName, "("]);
     p(["    ", ...inputType, " input, {"]);
     pMethodOptions();

--- a/packages/connect/bin/src/plugin.dart
+++ b/packages/connect/bin/src/plugin.dart
@@ -106,10 +106,9 @@ extension on GeneratedFile {
       importMsg(method.outputType),
       ">",
     ];
-    final inputType =
-        method.clientStreaming
-            ? ["Stream", "<", importMsg(method.inputType), ">"]
-            : [importMsg(method.inputType)];
+    final inputType = method.clientStreaming
+        ? ["Stream", "<", importMsg(method.inputType), ">"]
+        : [importMsg(method.inputType)];
     p(["  ", ...returnType, " ", method.localName, "("]);
     p(["    ", ...inputType, " input, {"]);
     pMethodOptions();

--- a/packages/connect/bin/src/run.dart
+++ b/packages/connect/bin/src/run.dart
@@ -69,7 +69,8 @@ Future<void> run(Stream<List<int>> input, Sink<List<int>> output) async {
   }
   final res = CodeGeneratorResponse();
   // Adding here instead of setting directly lets us avoid a direct dependency on fixnum package.
-  res.supportedFeatures = res.supportedFeatures +
+  res.supportedFeatures =
+      res.supportedFeatures +
       CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL.value;
   try {
     final files = generate(

--- a/packages/connect/bin/src/run.dart
+++ b/packages/connect/bin/src/run.dart
@@ -62,28 +62,25 @@ final class Schema {
 
 /// Runs the plugin by parsing the [input] into a [CodeGeneratorRequest]
 /// and writing the [CodeGeneratorResponse] to [output].
-Future<void> run(
-  Stream<List<int>> input,
-  Sink<List<int>> output,
-) async {
+Future<void> run(Stream<List<int>> input, Sink<List<int>> output) async {
   var reqBytes = Uint8List(0);
   await for (final chunk in input) {
     reqBytes = Uint8List.fromList(reqBytes + chunk);
   }
   final res = CodeGeneratorResponse();
   // Adding here instead of setting directly lets us avoid a direct dependency on fixnum package.
-  res.supportedFeatures = res.supportedFeatures +
+  res.supportedFeatures =
+      res.supportedFeatures +
       CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL.value;
   try {
-    final files = generate(Schema.fromProto(
-      CodeGeneratorRequest.fromBuffer(reqBytes),
-    ));
-    res.file.addAll(files.map(
-      (f) => CodeGeneratorResponse_File(
-        name: f.path,
-        content: f.content,
+    final files = generate(
+      Schema.fromProto(CodeGeneratorRequest.fromBuffer(reqBytes)),
+    );
+    res.file.addAll(
+      files.map(
+        (f) => CodeGeneratorResponse_File(name: f.path, content: f.content),
       ),
-    ));
+    );
   } catch (err) {
     res.error = err.toString();
   }

--- a/packages/connect/bin/src/run.dart
+++ b/packages/connect/bin/src/run.dart
@@ -69,8 +69,7 @@ Future<void> run(Stream<List<int>> input, Sink<List<int>> output) async {
   }
   final res = CodeGeneratorResponse();
   // Adding here instead of setting directly lets us avoid a direct dependency on fixnum package.
-  res.supportedFeatures =
-      res.supportedFeatures +
+  res.supportedFeatures = res.supportedFeatures +
       CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL.value;
   try {
     final files = generate(

--- a/packages/connect/lib/src/abort.dart
+++ b/packages/connect/lib/src/abort.dart
@@ -47,10 +47,9 @@ final class CancelableSignal with _AbortSignal {
 
   CancelableSignal({AbortSignal? parent}) {
     _deadline = parent?.deadline;
-    _future =
-        parent == null
-            ? _completer.future
-            : Future.any([parent.future, _completer.future]);
+    _future = parent == null
+        ? _completer.future
+        : Future.any([parent.future, _completer.future]);
   }
 }
 

--- a/packages/connect/lib/src/abort.dart
+++ b/packages/connect/lib/src/abort.dart
@@ -47,9 +47,10 @@ final class CancelableSignal with _AbortSignal {
 
   CancelableSignal({AbortSignal? parent}) {
     _deadline = parent?.deadline;
-    _future = parent == null
-        ? _completer.future
-        : Future.any([parent.future, _completer.future]);
+    _future =
+        parent == null
+            ? _completer.future
+            : Future.any([parent.future, _completer.future]);
   }
 }
 

--- a/packages/connect/lib/src/abort.dart
+++ b/packages/connect/lib/src/abort.dart
@@ -41,21 +41,16 @@ final class CancelableSignal with _AbortSignal {
   void cancel([Object? reason]) {
     if (_completer.isCompleted) return;
     _completer.complete(
-      super.errorFromReason(
-        reason,
-        Code.canceled,
-        'operation canceled',
-      ),
+      super.errorFromReason(reason, Code.canceled, 'operation canceled'),
     );
   }
 
   CancelableSignal({AbortSignal? parent}) {
     _deadline = parent?.deadline;
-    _future = parent == null
-        ? _completer.future
-        : Future.any(
-            [parent.future, _completer.future],
-          );
+    _future =
+        parent == null
+            ? _completer.future
+            : Future.any([parent.future, _completer.future]);
   }
 }
 
@@ -64,11 +59,7 @@ final class CancelableSignal with _AbortSignal {
 /// The signal will be trigerred before the deadline if the
 /// [parent] aborts.
 final class DeadlineSignal with _AbortSignal {
-  DeadlineSignal(
-    DateTime deadline, {
-    AbortSignal? parent,
-    Object? reason,
-  }) {
+  DeadlineSignal(DateTime deadline, {AbortSignal? parent, Object? reason}) {
     _deadline = switch (parent?.deadline) {
       final pDeadline? when pDeadline.isBefore(deadline) => pDeadline,
       _ => deadline,

--- a/packages/connect/lib/src/codec.dart
+++ b/packages/connect/lib/src/codec.dart
@@ -35,8 +35,5 @@ abstract interface class Codec {
   //
   // Decode may expect a specific type of message, and will error if this
   // type is not given.
-  void decode(
-    Uint8List data,
-    Object message,
-  );
+  void decode(Uint8List data, Object message);
 }

--- a/packages/connect/lib/src/connect/end_stream.dart
+++ b/packages/connect/lib/src/connect/end_stream.dart
@@ -44,30 +44,27 @@ final class EndStreamResponse {
     }
     final metadata = switch (json["metadata"]) {
       null => Headers(),
-      Map<String, dynamic> dict => dict.entries.fold(
-          Headers(),
-          (headers, entry) {
-            final values = entry.value;
-            if (values is! List<dynamic>) {
-              throw parseErr;
-            }
-            for (final value in values) {
-              if (value is! String) {
-                throw parseErr;
-              }
-              headers.add(entry.key, value);
-            }
-            return headers;
-          },
-        ),
+      Map<String, dynamic> dict => dict.entries.fold(Headers(), (
+        headers,
+        entry,
+      ) {
+        final values = entry.value;
+        if (values is! List<dynamic>) {
+          throw parseErr;
+        }
+        for (final value in values) {
+          if (value is! String) {
+            throw parseErr;
+          }
+          headers.add(entry.key, value);
+        }
+        return headers;
+      }),
       _ => throw parseErr,
     };
-    return EndStreamResponse(
-      metadata,
-      switch (json["error"]) {
-        null => null,
-        Object err => errorFromJson(err, metadata, parseErr)
-      },
-    );
+    return EndStreamResponse(metadata, switch (json["error"]) {
+      null => null,
+      Object err => errorFromJson(err, metadata, parseErr),
+    });
   }
 }

--- a/packages/connect/lib/src/connect/end_stream.dart
+++ b/packages/connect/lib/src/connect/end_stream.dart
@@ -45,26 +45,28 @@ final class EndStreamResponse {
     final metadata = switch (json["metadata"]) {
       null => Headers(),
       Map<String, dynamic> dict => dict.entries.fold(Headers(), (
-        headers,
-        entry,
-      ) {
-        final values = entry.value;
-        if (values is! List<dynamic>) {
-          throw parseErr;
-        }
-        for (final value in values) {
-          if (value is! String) {
+          headers,
+          entry,
+        ) {
+          final values = entry.value;
+          if (values is! List<dynamic>) {
             throw parseErr;
           }
-          headers.add(entry.key, value);
-        }
-        return headers;
-      }),
+          for (final value in values) {
+            if (value is! String) {
+              throw parseErr;
+            }
+            headers.add(entry.key, value);
+          }
+          return headers;
+        }),
       _ => throw parseErr,
     };
-    return EndStreamResponse(metadata, switch (json["error"]) {
-      null => null,
-      Object err => errorFromJson(err, metadata, parseErr),
-    });
+    return EndStreamResponse(
+        metadata,
+        switch (json["error"]) {
+          null => null,
+          Object err => errorFromJson(err, metadata, parseErr),
+        });
   }
 }

--- a/packages/connect/lib/src/connect/end_stream.dart
+++ b/packages/connect/lib/src/connect/end_stream.dart
@@ -45,28 +45,26 @@ final class EndStreamResponse {
     final metadata = switch (json["metadata"]) {
       null => Headers(),
       Map<String, dynamic> dict => dict.entries.fold(Headers(), (
-          headers,
-          entry,
-        ) {
-          final values = entry.value;
-          if (values is! List<dynamic>) {
+        headers,
+        entry,
+      ) {
+        final values = entry.value;
+        if (values is! List<dynamic>) {
+          throw parseErr;
+        }
+        for (final value in values) {
+          if (value is! String) {
             throw parseErr;
           }
-          for (final value in values) {
-            if (value is! String) {
-              throw parseErr;
-            }
-            headers.add(entry.key, value);
-          }
-          return headers;
-        }),
+          headers.add(entry.key, value);
+        }
+        return headers;
+      }),
       _ => throw parseErr,
     };
-    return EndStreamResponse(
-        metadata,
-        switch (json["error"]) {
-          null => null,
-          Object err => errorFromJson(err, metadata, parseErr),
-        });
+    return EndStreamResponse(metadata, switch (json["error"]) {
+      null => null,
+      Object err => errorFromJson(err, metadata, parseErr),
+    });
   }
 }

--- a/packages/connect/lib/src/connect/error_json.dart
+++ b/packages/connect/lib/src/connect/error_json.dart
@@ -46,9 +46,9 @@ ConnectException errorFromJson(
   }
   final code = switch (json['code']) {
     String code => Code.values.firstWhere(
-      (c) => c.name == code,
-      orElse: () => fallback.code,
-    ),
+        (c) => c.name == code,
+        orElse: () => fallback.code,
+      ),
     _ => fallback.code,
   };
   final message = switch (json['message']) {

--- a/packages/connect/lib/src/connect/error_json.dart
+++ b/packages/connect/lib/src/connect/error_json.dart
@@ -46,9 +46,9 @@ ConnectException errorFromJson(
   }
   final code = switch (json['code']) {
     String code => Code.values.firstWhere(
-        (c) => c.name == code,
-        orElse: () => fallback.code,
-      ),
+      (c) => c.name == code,
+      orElse: () => fallback.code,
+    ),
     _ => fallback.code,
   };
   final message = switch (json['message']) {
@@ -65,11 +65,7 @@ ConnectException errorFromJson(
           value = codec.normalize(value);
         }
         error.details.add(
-          ErrorDetail(
-            type,
-            base64.decode(value),
-            detail['debug'],
-          ),
+          ErrorDetail(type, base64.decode(value), detail['debug']),
         );
       } else {
         throw fallback;

--- a/packages/connect/lib/src/connect/error_json.dart
+++ b/packages/connect/lib/src/connect/error_json.dart
@@ -46,9 +46,9 @@ ConnectException errorFromJson(
   }
   final code = switch (json['code']) {
     String code => Code.values.firstWhere(
-        (c) => c.name == code,
-        orElse: () => fallback.code,
-      ),
+      (c) => c.name == code,
+      orElse: () => fallback.code,
+    ),
     _ => fallback.code,
   };
   final message = switch (json['message']) {

--- a/packages/connect/lib/src/connect/get.dart
+++ b/packages/connect/lib/src/connect/get.dart
@@ -22,17 +22,14 @@ String connectGetUrl(String url, StableCodec codec, Object message) {
   final messageBytes = codec.stableEncode(message);
   final buf = StringBuffer(url);
   buf.write("?");
-  buf.writeAll(
-    [
-      'connect=v$protocolVersion',
-      'encoding=${codec.name}',
-      if (codec.isBinary) 'base64=1',
-      if (codec.isBinary)
-        'message=${base64Url.encode(messageBytes)}'
-      else
-        'message=${Uri.encodeQueryComponent(utf8.decode(messageBytes))}',
-    ],
-    "&",
-  );
+  buf.writeAll([
+    'connect=v$protocolVersion',
+    'encoding=${codec.name}',
+    if (codec.isBinary) 'base64=1',
+    if (codec.isBinary)
+      'message=${base64Url.encode(messageBytes)}'
+    else
+      'message=${Uri.encodeQueryComponent(utf8.decode(messageBytes))}',
+  ], "&");
   return buf.toString();
 }

--- a/packages/connect/lib/src/connect/header.dart
+++ b/packages/connect/lib/src/connect/header.dart
@@ -38,34 +38,30 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header =
-      userProvidedHeaders == null
-          ? Headers()
-          : Headers.from(userProvidedHeaders);
+  final header = userProvidedHeaders == null
+      ? Headers()
+      : Headers.from(userProvidedHeaders);
   header[headerProtocolVersion] = protocolVersion;
   if (signal?.deadline case final deadline?) {
     header[headerTimeout] =
         deadline.difference(DateTime.now()).inMilliseconds.toString();
   }
-  header[headerContentType] =
-      streamType == StreamType.unary
-          ? 'application/${codec.name}'
-          : 'application/connect+${codec.name}';
+  header[headerContentType] = streamType == StreamType.unary
+      ? 'application/${codec.name}'
+      : 'application/connect+${codec.name}';
   if (!header.contains(headerUserAgent)) {
     header[headerUserAgent] = 'connect-dart/$version';
   }
   if (sendCompression != null) {
     header[streamType == StreamType.unary
-            ? headerUnaryEncoding
-            : headerStreamEncoding] =
-        sendCompression.name;
+        ? headerUnaryEncoding
+        : headerStreamEncoding] = sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
     header[streamType == StreamType.unary
-        ? headerUnaryAcceptEncoding
-        : headerStreamAcceptEncoding] = acceptCompressions
-        .map((c) => c.name)
-        .join(",");
+            ? headerUnaryAcceptEncoding
+            : headerStreamAcceptEncoding] =
+        acceptCompressions.map((c) => c.name).join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/connect/header.dart
+++ b/packages/connect/lib/src/connect/header.dart
@@ -38,30 +38,34 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header = userProvidedHeaders == null
-      ? Headers()
-      : Headers.from(userProvidedHeaders);
+  final header =
+      userProvidedHeaders == null
+          ? Headers()
+          : Headers.from(userProvidedHeaders);
   header[headerProtocolVersion] = protocolVersion;
   if (signal?.deadline case final deadline?) {
     header[headerTimeout] =
         deadline.difference(DateTime.now()).inMilliseconds.toString();
   }
-  header[headerContentType] = streamType == StreamType.unary
-      ? 'application/${codec.name}'
-      : 'application/connect+${codec.name}';
+  header[headerContentType] =
+      streamType == StreamType.unary
+          ? 'application/${codec.name}'
+          : 'application/connect+${codec.name}';
   if (!header.contains(headerUserAgent)) {
     header[headerUserAgent] = 'connect-dart/$version';
   }
   if (sendCompression != null) {
     header[streamType == StreamType.unary
-        ? headerUnaryEncoding
-        : headerStreamEncoding] = sendCompression.name;
+            ? headerUnaryEncoding
+            : headerStreamEncoding] =
+        sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
     header[streamType == StreamType.unary
-            ? headerUnaryAcceptEncoding
-            : headerStreamAcceptEncoding] =
-        acceptCompressions.map((c) => c.name).join(",");
+        ? headerUnaryAcceptEncoding
+        : headerStreamAcceptEncoding] = acceptCompressions
+        .map((c) => c.name)
+        .join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/connect/http_status.dart
+++ b/packages/connect/lib/src/connect/http_status.dart
@@ -18,22 +18,14 @@ import '../code.dart';
 /// See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
-    400 => // Bad Request
-    Code.internal,
-    401 => // Unauthorized
-    Code.unauthenticated,
-    403 => // Forbidden
-    Code.permissionDenied,
-    404 => // Not Found
-    Code.unimplemented,
-    429 => // Too Many Requests
-    Code.unavailable,
-    502 => // Bad Gateway
-    Code.unavailable,
-    503 => // Service Unavailable
-    Code.unavailable,
-    504 => // Gateway Timeout
-    Code.unavailable,
+    400 => Code.internal,           // Bad Request
+    401 => Code.unauthenticated,    // Unauthorized
+    403 => Code.permissionDenied,   // Forbidden
+    404 => Code.unimplemented,      // Not Found
+    429 => Code.unavailable,        // Too Many Requests
+    502 => Code.unavailable,        // Bad Gateway
+    503 => Code.unavailable,        // Service Unavailable
+    504 => Code.unavailable,        // Gateway Timeout
     _ => Code.unknown,
   };
 }

--- a/packages/connect/lib/src/connect/http_status.dart
+++ b/packages/connect/lib/src/connect/http_status.dart
@@ -18,14 +18,14 @@ import '../code.dart';
 /// See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
-    400 => Code.internal,           // Bad Request
-    401 => Code.unauthenticated,    // Unauthorized
-    403 => Code.permissionDenied,   // Forbidden
-    404 => Code.unimplemented,      // Not Found
-    429 => Code.unavailable,        // Too Many Requests
-    502 => Code.unavailable,        // Bad Gateway
-    503 => Code.unavailable,        // Service Unavailable
-    504 => Code.unavailable,        // Gateway Timeout
+    400 => Code.internal, // Bad Request
+    401 => Code.unauthenticated, // Unauthorized
+    403 => Code.permissionDenied, // Forbidden
+    404 => Code.unimplemented, // Not Found
+    429 => Code.unavailable, // Too Many Requests
+    502 => Code.unavailable, // Bad Gateway
+    503 => Code.unavailable, // Service Unavailable
+    504 => Code.unavailable, // Gateway Timeout
     _ => Code.unknown,
   };
 }

--- a/packages/connect/lib/src/connect/http_status.dart
+++ b/packages/connect/lib/src/connect/http_status.dart
@@ -19,21 +19,21 @@ import '../code.dart';
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
     400 => // Bad Request
-      Code.internal,
+    Code.internal,
     401 => // Unauthorized
-      Code.unauthenticated,
+    Code.unauthenticated,
     403 => // Forbidden
-      Code.permissionDenied,
+    Code.permissionDenied,
     404 => // Not Found
-      Code.unimplemented,
+    Code.unimplemented,
     429 => // Too Many Requests
-      Code.unavailable,
+    Code.unavailable,
     502 => // Bad Gateway
-      Code.unavailable,
+    Code.unavailable,
     503 => // Service Unavailable
-      Code.unavailable,
+    Code.unavailable,
     504 => // Gateway Timeout
-      Code.unavailable,
-    _ => Code.unknown
+    Code.unavailable,
+    _ => Code.unknown,
   };
 }

--- a/packages/connect/lib/src/connect/protocol.dart
+++ b/packages/connect/lib/src/connect/protocol.dart
@@ -149,12 +149,12 @@ final class Protocol implements base.Protocol {
             EndStreamResponse.fromJson,
           )
           .skipEndStream((endStream) {
-        if (endStream.error case ConnectException err) {
-          res.header.addAll(err.metadata);
-          throw err;
-        }
-        trailer.addAll(endStream.metadata);
-      }),
+            if (endStream.error case ConnectException err) {
+              res.header.addAll(err.metadata);
+              throw err;
+            }
+            trailer.addAll(endStream.metadata);
+          }),
       trailer,
     );
   }

--- a/packages/connect/lib/src/connect/protocol.dart
+++ b/packages/connect/lib/src/connect/protocol.dart
@@ -149,12 +149,12 @@ final class Protocol implements base.Protocol {
             EndStreamResponse.fromJson,
           )
           .skipEndStream((endStream) {
-            if (endStream.error case ConnectException err) {
-              res.header.addAll(err.metadata);
-              throw err;
-            }
-            trailer.addAll(endStream.metadata);
-          }),
+        if (endStream.error case ConnectException err) {
+          res.header.addAll(err.metadata);
+          throw err;
+        }
+        trailer.addAll(endStream.metadata);
+      }),
       trailer,
     );
   }

--- a/packages/connect/lib/src/connect/protocol.dart
+++ b/packages/connect/lib/src/connect/protocol.dart
@@ -103,11 +103,7 @@ final class Protocol implements base.Protocol {
       body = compression.decode(body);
     }
     if (unaryError != null) {
-      throw errorFromJsonBytes(
-        body,
-        headers..addAll(trailers),
-        unaryError,
-      );
+      throw errorFromJsonBytes(body, headers..addAll(trailers), unaryError);
     }
     return UnaryResponse(
       req.spec,
@@ -134,8 +130,11 @@ final class Protocol implements base.Protocol {
         req.signal,
       ),
     );
-    final (:compression, unaryError: _) =
-        res.validate(req.spec.streamType, codec, acceptCompressions);
+    final (:compression, unaryError: _) = res.validate(
+      req.spec.streamType,
+      codec,
+      acceptCompressions,
+    );
     final trailer = Headers();
     return StreamResponse(
       req.spec,
@@ -149,15 +148,13 @@ final class Protocol implements base.Protocol {
             endStreamFlag,
             EndStreamResponse.fromJson,
           )
-          .skipEndStream(
-        (endStream) {
-          if (endStream.error case ConnectException err) {
-            res.header.addAll(err.metadata);
-            throw err;
-          }
-          trailer.addAll(endStream.metadata);
-        },
-      ),
+          .skipEndStream((endStream) {
+            if (endStream.error case ConnectException err) {
+              res.header.addAll(err.metadata);
+              throw err;
+            }
+            trailer.addAll(endStream.metadata);
+          }),
       trailer,
     );
   }
@@ -166,9 +163,7 @@ final class Protocol implements base.Protocol {
 extension<O extends Object>
     on Stream<ParsedEnvelopedMessage<O, EndStreamResponse>> {
   /// Returns a stream of all the messages skipping the end stream message.
-  Stream<O> skipEndStream(
-    void Function(EndStreamResponse) onEndStream,
-  ) async* {
+  Stream<O> skipEndStream(void Function(EndStreamResponse) onEndStream) async* {
     var endStreamReceived = false;
     await for (final env in this) {
       if (endStreamReceived) {

--- a/packages/connect/lib/src/connect/response.dart
+++ b/packages/connect/lib/src/connect/response.dart
@@ -54,10 +54,9 @@ extension ResponseValidation on HttpResponse {
       }
       throw statusErr;
     }
-    final validPrefix =
-        streamType == StreamType.unary
-            ? "application/${codec.name}"
-            : "application/connect+${codec.name}";
+    final validPrefix = streamType == StreamType.unary
+        ? "application/${codec.name}"
+        : "application/connect+${codec.name}";
     if (!contentType.startsWith(validPrefix)) {
       /// The error code makes a distinction between a
       /// possible content type like application/json where a application/proto

--- a/packages/connect/lib/src/connect/response.dart
+++ b/packages/connect/lib/src/connect/response.dart
@@ -54,9 +54,10 @@ extension ResponseValidation on HttpResponse {
       }
       throw statusErr;
     }
-    final validPrefix = streamType == StreamType.unary
-        ? "application/${codec.name}"
-        : "application/connect+${codec.name}";
+    final validPrefix =
+        streamType == StreamType.unary
+            ? "application/${codec.name}"
+            : "application/connect+${codec.name}";
     if (!contentType.startsWith(validPrefix)) {
       /// The error code makes a distinction between a
       /// possible content type like application/json where a application/proto

--- a/packages/connect/lib/src/connect/transport.dart
+++ b/packages/connect/lib/src/connect/transport.dart
@@ -30,12 +30,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-          baseUrl,
-          codec,
-          Protocol(useHttpGet),
-          httpClient,
-          interceptors ?? [],
-          sendCompression,
-          acceptCompressions ?? [],
-        );
+         baseUrl,
+         codec,
+         Protocol(useHttpGet),
+         httpClient,
+         interceptors ?? [],
+         sendCompression,
+         acceptCompressions ?? [],
+       );
 }

--- a/packages/connect/lib/src/connect/transport.dart
+++ b/packages/connect/lib/src/connect/transport.dart
@@ -30,12 +30,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-         baseUrl,
-         codec,
-         Protocol(useHttpGet),
-         httpClient,
-         interceptors ?? [],
-         sendCompression,
-         acceptCompressions ?? [],
-       );
+          baseUrl,
+          codec,
+          Protocol(useHttpGet),
+          httpClient,
+          interceptors ?? [],
+          sendCompression,
+          acceptCompressions ?? [],
+        );
 }

--- a/packages/connect/lib/src/fake.dart
+++ b/packages/connect/lib/src/fake.dart
@@ -39,10 +39,7 @@ final class FakeTransportBuilder {
   /// Register a unary handler.
   FakeTransportBuilder unary<I extends Object, O extends Object>(
     Spec<I, O> spec,
-    FutureOr<O> Function(
-      I request,
-      FakeHandlerContext context,
-    ) handler,
+    FutureOr<O> Function(I request, FakeHandlerContext context) handler,
   ) {
     _assertSpecStream(spec, StreamType.unary);
     _handlers[spec] = handler;
@@ -52,10 +49,7 @@ final class FakeTransportBuilder {
   /// Register a client streaming handler.
   FakeTransportBuilder client<I extends Object, O extends Object>(
     Spec<I, O> spec,
-    FutureOr<O> Function(
-      Stream<I> request,
-      FakeHandlerContext context,
-    ) handler,
+    FutureOr<O> Function(Stream<I> request, FakeHandlerContext context) handler,
   ) {
     _assertSpecStream(spec, StreamType.client);
     _handlers[spec] = _clientToStream(handler);
@@ -65,10 +59,7 @@ final class FakeTransportBuilder {
   /// Register a server streaming handler.
   FakeTransportBuilder server<I extends Object, O extends Object>(
     Spec<I, O> spec,
-    Stream<O> Function(
-      I request,
-      FakeHandlerContext context,
-    ) handler,
+    Stream<O> Function(I request, FakeHandlerContext context) handler,
   ) {
     _assertSpecStream(spec, StreamType.server);
     _handlers[spec] = _serverToStream(handler);
@@ -78,10 +69,7 @@ final class FakeTransportBuilder {
   /// Register a bidi streaming handler.
   FakeTransportBuilder bidi<I extends Object, O extends Object>(
     Spec<I, O> spec,
-    Stream<O> Function(
-      Stream<I> request,
-      FakeHandlerContext context,
-    ) handler,
+    Stream<O> Function(Stream<I> request, FakeHandlerContext context) handler,
   ) {
     _assertSpecStream(spec, StreamType.bidi);
     _handlers[spec] = handler;
@@ -89,26 +77,17 @@ final class FakeTransportBuilder {
   }
 
   /// Build the transport.
-  Transport build({
-    List<Interceptor>? interceptors,
-  }) {
-    return _FakeTransport(
-      Map.from(_handlers),
-      interceptors,
-    );
+  Transport build({List<Interceptor>? interceptors}) {
+    return _FakeTransport(Map.from(_handlers), interceptors);
   }
 
-  _StreamHandler<I, O> _clientToStream<I, O>(
-    _ClientHandler<I, O> client,
-  ) {
+  _StreamHandler<I, O> _clientToStream<I, O>(_ClientHandler<I, O> client) {
     return (req, context) async* {
       yield await client(req, context);
     };
   }
 
-  _StreamHandler<I, O> _serverToStream<I, O>(
-    _ServerHandler<I, O> server,
-  ) {
+  _StreamHandler<I, O> _serverToStream<I, O>(_ServerHandler<I, O> server) {
     return (req, context) async* {
       yield* server(await req.first, context);
     };
@@ -151,14 +130,14 @@ final class _FakeTransport extends ProtocolTransport {
     Map<Spec<Object, Object>, Function> handlers,
     List<Interceptor>? interceptors,
   ) : super(
-          "test://test",
-          _FakeCodec(),
-          _FakeProtocol(handlers),
-          (req) => throw UnimplementedError(),
-          interceptors ?? [],
-          null,
-          [],
-        );
+        "test://test",
+        _FakeCodec(),
+        _FakeProtocol(handlers),
+        (req) => throw UnimplementedError(),
+        interceptors ?? [],
+        null,
+        [],
+      );
 }
 
 final class _FakeProtocol implements Protocol {
@@ -202,12 +181,7 @@ final class _FakeProtocol implements Protocol {
       headers,
       await (handler as _UnaryHandler<I, O>)(
         req.message,
-        FakeHandlerContext._(
-          req.signal,
-          req.headers,
-          headers,
-          trailers,
-        ),
+        FakeHandlerContext._(req.signal, req.headers, headers, trailers),
       ),
       trailers,
     );
@@ -235,16 +209,17 @@ final class _FakeProtocol implements Protocol {
     );
     final trailers = Headers();
     final messages = await (handler as _StreamHandler<I, O>)(
-      req.message,
-      context,
-      // If we do not wait for the first value headers will not be visible
-    ).untilFirst(
-      // Similarly we also wait for the last message to replicate the server
-      // behaviour of only sending trailers at the end.
-      () {
-        trailers.addAll(context.responseTrailers);
-      },
-    );
+          req.message,
+          context,
+          // If we do not wait for the first value headers will not be visible
+        )
+        .untilFirst(
+          // Similarly we also wait for the last message to replicate the server
+          // behaviour of only sending trailers at the end.
+          () {
+            trailers.addAll(context.responseTrailers);
+          },
+        );
     return StreamResponse(
       req.spec,
       // Cloning will replicate actual server behaviour of only headers before the first response being visible.
@@ -255,25 +230,17 @@ final class _FakeProtocol implements Protocol {
   }
 }
 
-typedef _UnaryHandler<I, O> = FutureOr<O> Function(
-  I request,
-  FakeHandlerContext context,
-);
+typedef _UnaryHandler<I, O> =
+    FutureOr<O> Function(I request, FakeHandlerContext context);
 
-typedef _StreamHandler<I, O> = Stream<O> Function(
-  Stream<I> request,
-  FakeHandlerContext context,
-);
+typedef _StreamHandler<I, O> =
+    Stream<O> Function(Stream<I> request, FakeHandlerContext context);
 
-typedef _ClientHandler<I, O> = FutureOr<O> Function(
-  Stream<I> request,
-  FakeHandlerContext context,
-);
+typedef _ClientHandler<I, O> =
+    FutureOr<O> Function(Stream<I> request, FakeHandlerContext context);
 
-typedef _ServerHandler<I, O> = Stream<O> Function(
-  I request,
-  FakeHandlerContext context,
-);
+typedef _ServerHandler<I, O> =
+    Stream<O> Function(I request, FakeHandlerContext context);
 
 final class _FakeCodec implements Codec {
   @override

--- a/packages/connect/lib/src/fake.dart
+++ b/packages/connect/lib/src/fake.dart
@@ -130,14 +130,14 @@ final class _FakeTransport extends ProtocolTransport {
     Map<Spec<Object, Object>, Function> handlers,
     List<Interceptor>? interceptors,
   ) : super(
-        "test://test",
-        _FakeCodec(),
-        _FakeProtocol(handlers),
-        (req) => throw UnimplementedError(),
-        interceptors ?? [],
-        null,
-        [],
-      );
+          "test://test",
+          _FakeCodec(),
+          _FakeProtocol(handlers),
+          (req) => throw UnimplementedError(),
+          interceptors ?? [],
+          null,
+          [],
+        );
 }
 
 final class _FakeProtocol implements Protocol {
@@ -209,17 +209,16 @@ final class _FakeProtocol implements Protocol {
     );
     final trailers = Headers();
     final messages = await (handler as _StreamHandler<I, O>)(
-          req.message,
-          context,
-          // If we do not wait for the first value headers will not be visible
-        )
-        .untilFirst(
-          // Similarly we also wait for the last message to replicate the server
-          // behaviour of only sending trailers at the end.
-          () {
-            trailers.addAll(context.responseTrailers);
-          },
-        );
+      req.message,
+      context,
+      // If we do not wait for the first value headers will not be visible
+    ).untilFirst(
+      // Similarly we also wait for the last message to replicate the server
+      // behaviour of only sending trailers at the end.
+      () {
+        trailers.addAll(context.responseTrailers);
+      },
+    );
     return StreamResponse(
       req.spec,
       // Cloning will replicate actual server behaviour of only headers before the first response being visible.
@@ -230,17 +229,17 @@ final class _FakeProtocol implements Protocol {
   }
 }
 
-typedef _UnaryHandler<I, O> =
-    FutureOr<O> Function(I request, FakeHandlerContext context);
+typedef _UnaryHandler<I, O> = FutureOr<O> Function(
+    I request, FakeHandlerContext context);
 
-typedef _StreamHandler<I, O> =
-    Stream<O> Function(Stream<I> request, FakeHandlerContext context);
+typedef _StreamHandler<I, O> = Stream<O> Function(
+    Stream<I> request, FakeHandlerContext context);
 
-typedef _ClientHandler<I, O> =
-    FutureOr<O> Function(Stream<I> request, FakeHandlerContext context);
+typedef _ClientHandler<I, O> = FutureOr<O> Function(
+    Stream<I> request, FakeHandlerContext context);
 
-typedef _ServerHandler<I, O> =
-    Stream<O> Function(I request, FakeHandlerContext context);
+typedef _ServerHandler<I, O> = Stream<O> Function(
+    I request, FakeHandlerContext context);
 
 final class _FakeCodec implements Codec {
   @override

--- a/packages/connect/lib/src/fake.dart
+++ b/packages/connect/lib/src/fake.dart
@@ -130,14 +130,14 @@ final class _FakeTransport extends ProtocolTransport {
     Map<Spec<Object, Object>, Function> handlers,
     List<Interceptor>? interceptors,
   ) : super(
-          "test://test",
-          _FakeCodec(),
-          _FakeProtocol(handlers),
-          (req) => throw UnimplementedError(),
-          interceptors ?? [],
-          null,
-          [],
-        );
+        "test://test",
+        _FakeCodec(),
+        _FakeProtocol(handlers),
+        (req) => throw UnimplementedError(),
+        interceptors ?? [],
+        null,
+        [],
+      );
 }
 
 final class _FakeProtocol implements Protocol {
@@ -209,16 +209,17 @@ final class _FakeProtocol implements Protocol {
     );
     final trailers = Headers();
     final messages = await (handler as _StreamHandler<I, O>)(
-      req.message,
-      context,
-      // If we do not wait for the first value headers will not be visible
-    ).untilFirst(
-      // Similarly we also wait for the last message to replicate the server
-      // behaviour of only sending trailers at the end.
-      () {
-        trailers.addAll(context.responseTrailers);
-      },
-    );
+          req.message,
+          context,
+          // If we do not wait for the first value headers will not be visible
+        )
+        .untilFirst(
+          // Similarly we also wait for the last message to replicate the server
+          // behaviour of only sending trailers at the end.
+          () {
+            trailers.addAll(context.responseTrailers);
+          },
+        );
     return StreamResponse(
       req.spec,
       // Cloning will replicate actual server behaviour of only headers before the first response being visible.
@@ -229,17 +230,17 @@ final class _FakeProtocol implements Protocol {
   }
 }
 
-typedef _UnaryHandler<I, O> = FutureOr<O> Function(
-    I request, FakeHandlerContext context);
+typedef _UnaryHandler<I, O> =
+    FutureOr<O> Function(I request, FakeHandlerContext context);
 
-typedef _StreamHandler<I, O> = Stream<O> Function(
-    Stream<I> request, FakeHandlerContext context);
+typedef _StreamHandler<I, O> =
+    Stream<O> Function(Stream<I> request, FakeHandlerContext context);
 
-typedef _ClientHandler<I, O> = FutureOr<O> Function(
-    Stream<I> request, FakeHandlerContext context);
+typedef _ClientHandler<I, O> =
+    FutureOr<O> Function(Stream<I> request, FakeHandlerContext context);
 
-typedef _ServerHandler<I, O> = Stream<O> Function(
-    I request, FakeHandlerContext context);
+typedef _ServerHandler<I, O> =
+    Stream<O> Function(I request, FakeHandlerContext context);
 
 final class _FakeCodec implements Codec {
   @override

--- a/packages/connect/lib/src/fetch_bindings.dart
+++ b/packages/connect/lib/src/fetch_bindings.dart
@@ -46,8 +46,7 @@ extension type Headers._(JSObject _) implements JSObject {
   Iterable<({String key, String value})> entries() {
     // Instread of creating bindings for the iterable, we opaquely pass the
     // iterbale to Array.from and convert that to a dart list.
-    return _HeaderEntriesArray.from(_entries())
-        .toDart
+    return _HeaderEntriesArray.from(_entries()).toDart
         .map((e) => e.toDart)
         .map((e) => (key: e.first.toDart, value: e.last.toDart));
   }

--- a/packages/connect/lib/src/fetch_bindings.dart
+++ b/packages/connect/lib/src/fetch_bindings.dart
@@ -46,7 +46,8 @@ extension type Headers._(JSObject _) implements JSObject {
   Iterable<({String key, String value})> entries() {
     // Instread of creating bindings for the iterable, we opaquely pass the
     // iterbale to Array.from and convert that to a dart list.
-    return _HeaderEntriesArray.from(_entries()).toDart
+    return _HeaderEntriesArray.from(_entries())
+        .toDart
         .map((e) => e.toDart)
         .map((e) => (key: e.first.toDart, value: e.last.toDart));
   }

--- a/packages/connect/lib/src/grpc/http_status.dart
+++ b/packages/connect/lib/src/grpc/http_status.dart
@@ -18,14 +18,15 @@ import '../../connect.dart';
 /// See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
-    400 => Code.internal,           // Bad Request
-    401 => Code.unauthenticated,    // Unauthorized
-    403 => Code.permissionDenied,   // Forbidden
-    404 => Code.unimplemented,      // Not Found
-    429 => Code.unavailable,        // Too Many Requests
-    502 => Code.unavailable,        // Bad Gateway
-    503 => Code.unavailable,        // Service Unavailable
-    504 => Code.unavailable,        // Gateway Timeout
-    _ =>   Code.unknown,            // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
+    400 => Code.internal, // Bad Request
+    401 => Code.unauthenticated, // Unauthorized
+    403 => Code.permissionDenied, // Forbidden
+    404 => Code.unimplemented, // Not Found
+    429 => Code.unavailable, // Too Many Requests
+    502 => Code.unavailable, // Bad Gateway
+    503 => Code.unavailable, // Service Unavailable
+    504 => Code.unavailable, // Gateway Timeout
+    _ => Code
+        .unknown, // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
   };
 }

--- a/packages/connect/lib/src/grpc/http_status.dart
+++ b/packages/connect/lib/src/grpc/http_status.dart
@@ -19,23 +19,23 @@ import '../../connect.dart';
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
     400 => // Bad Request
-      Code.internal,
+    Code.internal,
     401 => // Unauthorized
-      Code.unauthenticated,
+    Code.unauthenticated,
     403 => // Forbidden
-      Code.permissionDenied,
+    Code.permissionDenied,
     404 => // Not Found
-      Code.unimplemented,
+    Code.unimplemented,
     429 => // Too Many Requests
-      Code.unavailable,
+    Code.unavailable,
     502 => // Bad Gateway
-      Code.unavailable,
+    Code.unavailable,
     503 => // Service Unavailable
-      Code.unavailable,
+    Code.unavailable,
     504 => // Gateway Timeout
-      Code.unavailable,
+    Code.unavailable,
     _ =>
       // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
-      Code.unknown
+      Code.unknown,
   };
 }

--- a/packages/connect/lib/src/grpc/http_status.dart
+++ b/packages/connect/lib/src/grpc/http_status.dart
@@ -26,7 +26,7 @@ Code codeFromHttpStatus(int httpStatus) {
     502 => Code.unavailable, // Bad Gateway
     503 => Code.unavailable, // Service Unavailable
     504 => Code.unavailable, // Gateway Timeout
-    _ => Code
-        .unknown, // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
+    _ =>
+      Code.unknown, // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
   };
 }

--- a/packages/connect/lib/src/grpc/http_status.dart
+++ b/packages/connect/lib/src/grpc/http_status.dart
@@ -18,24 +18,14 @@ import '../../connect.dart';
 /// See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
 Code codeFromHttpStatus(int httpStatus) {
   return switch (httpStatus) {
-    400 => // Bad Request
-    Code.internal,
-    401 => // Unauthorized
-    Code.unauthenticated,
-    403 => // Forbidden
-    Code.permissionDenied,
-    404 => // Not Found
-    Code.unimplemented,
-    429 => // Too Many Requests
-    Code.unavailable,
-    502 => // Bad Gateway
-    Code.unavailable,
-    503 => // Service Unavailable
-    Code.unavailable,
-    504 => // Gateway Timeout
-    Code.unavailable,
-    _ =>
-      // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
-      Code.unknown,
+    400 => Code.internal,           // Bad Request
+    401 => Code.unauthenticated,    // Unauthorized
+    403 => Code.permissionDenied,   // Forbidden
+    404 => Code.unimplemented,      // Not Found
+    429 => Code.unavailable,        // Too Many Requests
+    502 => Code.unavailable,        // Bad Gateway
+    503 => Code.unavailable,        // Service Unavailable
+    504 => Code.unavailable,        // Gateway Timeout
+    _ =>   Code.unknown,            // 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.
   };
 }

--- a/packages/connect/lib/src/grpc/protocol.dart
+++ b/packages/connect/lib/src/grpc/protocol.dart
@@ -67,10 +67,9 @@ final class Protocol implements base.Protocol {
         req.url,
         "POST",
         req.headers,
-        Stream.fromIterable([req.message])
-            .serialize(codec)
-            .compress(sendCompression)
-            .joinEnvelope(),
+        Stream.fromIterable([
+          req.message,
+        ]).serialize(codec).compress(sendCompression).joinEnvelope(),
         req.signal,
       ),
     );
@@ -78,11 +77,12 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final message = await res.body
-        .splitEnvelope()
-        .decompress(compression)
-        .parse(codec, req.spec.outputFactory)
-        .tryReadingSingleMessage();
+    final message =
+        await res.body
+            .splitEnvelope()
+            .decompress(compression)
+            .parse(codec, req.spec.outputFactory)
+            .tryReadingSingleMessage();
     res.trailer.validateTrailer(res.header, statusParser);
     if (message == null) {
       if (headerError != null) {
@@ -103,12 +103,7 @@ final class Protocol implements base.Protocol {
         'with error status',
       );
     }
-    return UnaryResponse(
-      req.spec,
-      res.header,
-      message,
-      res.trailer,
-    );
+    return UnaryResponse(req.spec, res.header, message, res.trailer);
   }
 
   @override
@@ -144,10 +139,10 @@ final class Protocol implements base.Protocol {
           .decompress(compression)
           .parse(codec, req.spec.outputFactory)
           .onDone(() {
-        if (!foundStatus) {
-          res.trailer.validateTrailer(res.header, statusParser);
-        }
-      }),
+            if (!foundStatus) {
+              res.trailer.validateTrailer(res.header, statusParser);
+            }
+          }),
       res.trailer,
     );
   }

--- a/packages/connect/lib/src/grpc/protocol.dart
+++ b/packages/connect/lib/src/grpc/protocol.dart
@@ -77,11 +77,12 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final message = await res.body
-        .splitEnvelope()
-        .decompress(compression)
-        .parse(codec, req.spec.outputFactory)
-        .tryReadingSingleMessage();
+    final message =
+        await res.body
+            .splitEnvelope()
+            .decompress(compression)
+            .parse(codec, req.spec.outputFactory)
+            .tryReadingSingleMessage();
     res.trailer.validateTrailer(res.header, statusParser);
     if (message == null) {
       if (headerError != null) {
@@ -138,10 +139,10 @@ final class Protocol implements base.Protocol {
           .decompress(compression)
           .parse(codec, req.spec.outputFactory)
           .onDone(() {
-        if (!foundStatus) {
-          res.trailer.validateTrailer(res.header, statusParser);
-        }
-      }),
+            if (!foundStatus) {
+              res.trailer.validateTrailer(res.header, statusParser);
+            }
+          }),
       res.trailer,
     );
   }

--- a/packages/connect/lib/src/grpc/protocol.dart
+++ b/packages/connect/lib/src/grpc/protocol.dart
@@ -77,12 +77,11 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final message =
-        await res.body
-            .splitEnvelope()
-            .decompress(compression)
-            .parse(codec, req.spec.outputFactory)
-            .tryReadingSingleMessage();
+    final message = await res.body
+        .splitEnvelope()
+        .decompress(compression)
+        .parse(codec, req.spec.outputFactory)
+        .tryReadingSingleMessage();
     res.trailer.validateTrailer(res.header, statusParser);
     if (message == null) {
       if (headerError != null) {
@@ -139,10 +138,10 @@ final class Protocol implements base.Protocol {
           .decompress(compression)
           .parse(codec, req.spec.outputFactory)
           .onDone(() {
-            if (!foundStatus) {
-              res.trailer.validateTrailer(res.header, statusParser);
-            }
-          }),
+        if (!foundStatus) {
+          res.trailer.validateTrailer(res.header, statusParser);
+        }
+      }),
       res.trailer,
     );
   }

--- a/packages/connect/lib/src/grpc/request_header.dart
+++ b/packages/connect/lib/src/grpc/request_header.dart
@@ -28,9 +28,10 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header = userProvidedHeaders == null
-      ? Headers()
-      : Headers.from(userProvidedHeaders);
+  final header =
+      userProvidedHeaders == null
+          ? Headers()
+          : Headers.from(userProvidedHeaders);
   header[headerContentType] = '$contentTypePrefix+${codec.name}';
   if (signal?.deadline case final deadline?) {
     header[headerTimeout] =
@@ -46,8 +47,9 @@ Headers requestHeader(
     header[headerEncoding] = sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
-    header[headerAcceptEncoding] =
-        acceptCompressions.map((c) => c.name).join(",");
+    header[headerAcceptEncoding] = acceptCompressions
+        .map((c) => c.name)
+        .join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/grpc/request_header.dart
+++ b/packages/connect/lib/src/grpc/request_header.dart
@@ -28,10 +28,9 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header =
-      userProvidedHeaders == null
-          ? Headers()
-          : Headers.from(userProvidedHeaders);
+  final header = userProvidedHeaders == null
+      ? Headers()
+      : Headers.from(userProvidedHeaders);
   header[headerContentType] = '$contentTypePrefix+${codec.name}';
   if (signal?.deadline case final deadline?) {
     header[headerTimeout] =
@@ -47,9 +46,8 @@ Headers requestHeader(
     header[headerEncoding] = sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
-    header[headerAcceptEncoding] = acceptCompressions
-        .map((c) => c.name)
-        .join(",");
+    header[headerAcceptEncoding] =
+        acceptCompressions.map((c) => c.name).join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/grpc/response.dart
+++ b/packages/connect/lib/src/grpc/response.dart
@@ -33,8 +33,11 @@ extension ResponseValidation on HttpResponse {
   /// Returns an object that indicates whether a gRPC status was found
   /// in the response header. In this case, clients can not expect a
   /// trailer.
-  ({bool foundStatus, ConnectException? headerError, Compression? compression})
-  validate(StatusParser statusParser, List<Compression> acceptCompressions) {
+  ({
+    bool foundStatus,
+    ConnectException? headerError,
+    Compression? compression
+  }) validate(StatusParser statusParser, List<Compression> acceptCompressions) {
     if (status != 200) {
       throw ConnectException(
         codeFromHttpStatus(status),

--- a/packages/connect/lib/src/grpc/response.dart
+++ b/packages/connect/lib/src/grpc/response.dart
@@ -33,14 +33,8 @@ extension ResponseValidation on HttpResponse {
   /// Returns an object that indicates whether a gRPC status was found
   /// in the response header. In this case, clients can not expect a
   /// trailer.
-  ({
-    bool foundStatus,
-    ConnectException? headerError,
-    Compression? compression,
-  }) validate(
-    StatusParser statusParser,
-    List<Compression> acceptCompressions,
-  ) {
+  ({bool foundStatus, ConnectException? headerError, Compression? compression})
+  validate(StatusParser statusParser, List<Compression> acceptCompressions) {
     if (status != 200) {
       throw ConnectException(
         codeFromHttpStatus(status),
@@ -59,7 +53,7 @@ extension ResponseValidation on HttpResponse {
     return (
       foundStatus: header.contains(headerGrpcStatus),
       headerError: header.findError(statusParser),
-      compression: findCompression(acceptCompressions, headerEncoding)
+      compression: findCompression(acceptCompressions, headerEncoding),
     );
   }
 }

--- a/packages/connect/lib/src/grpc/response.dart
+++ b/packages/connect/lib/src/grpc/response.dart
@@ -33,11 +33,8 @@ extension ResponseValidation on HttpResponse {
   /// Returns an object that indicates whether a gRPC status was found
   /// in the response header. In this case, clients can not expect a
   /// trailer.
-  ({
-    bool foundStatus,
-    ConnectException? headerError,
-    Compression? compression
-  }) validate(StatusParser statusParser, List<Compression> acceptCompressions) {
+  ({bool foundStatus, ConnectException? headerError, Compression? compression})
+  validate(StatusParser statusParser, List<Compression> acceptCompressions) {
     if (status != 200) {
       throw ConnectException(
         codeFromHttpStatus(status),

--- a/packages/connect/lib/src/grpc/trailer.dart
+++ b/packages/connect/lib/src/grpc/trailer.dart
@@ -23,10 +23,7 @@ import 'trailer_error.dart';
 extension TrailerValidation on Headers {
   /// Validates a trailer for the gRPC and the gRPC-web protocol.
   /// Throws a [ConnectException] if the trailer contains an error status.
-  void validateTrailer(
-    Headers headers,
-    StatusParser statusParser,
-  ) {
+  void validateTrailer(Headers headers, StatusParser statusParser) {
     final err = findError(statusParser);
     if (err != null) {
       for (final header in headers.entries) {
@@ -38,10 +35,7 @@ extension TrailerValidation on Headers {
         !contains(headerStatusDetailsBin) &&
         !headers.contains(headerGrpcStatus) &&
         !headers.contains(headerStatusDetailsBin)) {
-      throw ConnectException(
-        Code.internal,
-        'protocol error: missing status',
-      );
+      throw ConnectException(Code.internal, 'protocol error: missing status');
     }
   }
 }

--- a/packages/connect/lib/src/grpc/transport.dart
+++ b/packages/connect/lib/src/grpc/transport.dart
@@ -34,12 +34,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-          baseUrl,
-          codec,
-          Protocol(statusParser, sendCompression),
-          httpClient,
-          interceptors ?? [],
-          sendCompression,
-          acceptCompressions ?? [],
-        );
+         baseUrl,
+         codec,
+         Protocol(statusParser, sendCompression),
+         httpClient,
+         interceptors ?? [],
+         sendCompression,
+         acceptCompressions ?? [],
+       );
 }

--- a/packages/connect/lib/src/grpc/transport.dart
+++ b/packages/connect/lib/src/grpc/transport.dart
@@ -34,12 +34,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-         baseUrl,
-         codec,
-         Protocol(statusParser, sendCompression),
-         httpClient,
-         interceptors ?? [],
-         sendCompression,
-         acceptCompressions ?? [],
-       );
+          baseUrl,
+          codec,
+          Protocol(statusParser, sendCompression),
+          httpClient,
+          interceptors ?? [],
+          sendCompression,
+          acceptCompressions ?? [],
+        );
 }

--- a/packages/connect/lib/src/grpc_web/protocol.dart
+++ b/packages/connect/lib/src/grpc_web/protocol.dart
@@ -69,10 +69,9 @@ final class Protocol implements base.Protocol {
         req.url,
         "POST",
         req.headers,
-        Stream.fromIterable([req.message])
-            .serialize(codec)
-            .compress(sendCompression)
-            .joinEnvelope(),
+        Stream.fromIterable([
+          req.message,
+        ]).serialize(codec).compress(sendCompression).joinEnvelope(),
         req.signal,
       ),
     );
@@ -80,16 +79,12 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final (message, trailer) = await res.body
-        .splitEnvelope()
-        .decompress(compression)
-        .parse(
-          codec,
-          req.spec.outputFactory,
-          trailerFlag,
-          parseTrailer,
-        )
-        .tryReadSingleMessage();
+    final (message, trailer) =
+        await res.body
+            .splitEnvelope()
+            .decompress(compression)
+            .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
+            .tryReadSingleMessage();
     if (trailer == null) {
       if (headerError != null) {
         throw headerError;
@@ -106,12 +101,7 @@ final class Protocol implements base.Protocol {
         "protocol error: missing output message for unary method",
       );
     }
-    return UnaryResponse(
-      req.spec,
-      res.header,
-      message,
-      trailer,
-    );
+    return UnaryResponse(req.spec, res.header, message, trailer);
   }
 
   @override
@@ -145,20 +135,12 @@ final class Protocol implements base.Protocol {
       res.body
           .splitEnvelope()
           .decompress(compression)
-          .parse(
-            codec,
-            req.spec.outputFactory,
-            trailerFlag,
-            parseTrailer,
-          )
-          .skipTrailer(
-        foundStatus,
-        (recvTrailers) {
-          trailer.addAll(
-            recvTrailers..validateTrailer(req.headers, statusParser),
-          );
-        },
-      ),
+          .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
+          .skipTrailer(foundStatus, (recvTrailers) {
+            trailer.addAll(
+              recvTrailers..validateTrailer(req.headers, statusParser),
+            );
+          }),
       trailer,
     );
   }
@@ -199,10 +181,7 @@ extension<O extends Object> on Stream<ParsedEnvelopedMessage<O, Headers>> {
       }
     }
     if (!trailerReceived) {
-      throw ConnectException(
-        Code.internal,
-        "protocol error: missing trailer",
-      );
+      throw ConnectException(Code.internal, "protocol error: missing trailer");
     }
   }
 

--- a/packages/connect/lib/src/grpc_web/protocol.dart
+++ b/packages/connect/lib/src/grpc_web/protocol.dart
@@ -79,12 +79,11 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final (message, trailer) =
-        await res.body
-            .splitEnvelope()
-            .decompress(compression)
-            .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
-            .tryReadSingleMessage();
+    final (message, trailer) = await res.body
+        .splitEnvelope()
+        .decompress(compression)
+        .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
+        .tryReadSingleMessage();
     if (trailer == null) {
       if (headerError != null) {
         throw headerError;
@@ -137,10 +136,10 @@ final class Protocol implements base.Protocol {
           .decompress(compression)
           .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
           .skipTrailer(foundStatus, (recvTrailers) {
-            trailer.addAll(
-              recvTrailers..validateTrailer(req.headers, statusParser),
-            );
-          }),
+        trailer.addAll(
+          recvTrailers..validateTrailer(req.headers, statusParser),
+        );
+      }),
       trailer,
     );
   }

--- a/packages/connect/lib/src/grpc_web/protocol.dart
+++ b/packages/connect/lib/src/grpc_web/protocol.dart
@@ -79,11 +79,12 @@ final class Protocol implements base.Protocol {
       statusParser,
       acceptCompressions,
     );
-    final (message, trailer) = await res.body
-        .splitEnvelope()
-        .decompress(compression)
-        .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
-        .tryReadSingleMessage();
+    final (message, trailer) =
+        await res.body
+            .splitEnvelope()
+            .decompress(compression)
+            .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
+            .tryReadSingleMessage();
     if (trailer == null) {
       if (headerError != null) {
         throw headerError;
@@ -136,10 +137,10 @@ final class Protocol implements base.Protocol {
           .decompress(compression)
           .parse(codec, req.spec.outputFactory, trailerFlag, parseTrailer)
           .skipTrailer(foundStatus, (recvTrailers) {
-        trailer.addAll(
-          recvTrailers..validateTrailer(req.headers, statusParser),
-        );
-      }),
+            trailer.addAll(
+              recvTrailers..validateTrailer(req.headers, statusParser),
+            );
+          }),
       trailer,
     );
   }

--- a/packages/connect/lib/src/grpc_web/request_header.dart
+++ b/packages/connect/lib/src/grpc_web/request_header.dart
@@ -35,9 +35,10 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header = userProvidedHeaders == null
-      ? Headers()
-      : Headers.from(userProvidedHeaders);
+  final header =
+      userProvidedHeaders == null
+          ? Headers()
+          : Headers.from(userProvidedHeaders);
   header.add(headerXGrpcWeb, "1");
   // Note that we do not support the grpc-web-text format.
   // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
@@ -53,8 +54,9 @@ Headers requestHeader(
     header[headerEncoding] = sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
-    header[headerAcceptEncoding] =
-        acceptCompressions.map((c) => c.name).join(",");
+    header[headerAcceptEncoding] = acceptCompressions
+        .map((c) => c.name)
+        .join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/grpc_web/request_header.dart
+++ b/packages/connect/lib/src/grpc_web/request_header.dart
@@ -35,10 +35,9 @@ Headers requestHeader(
   Compression? sendCompression,
   List<Compression> acceptCompressions,
 ) {
-  final header =
-      userProvidedHeaders == null
-          ? Headers()
-          : Headers.from(userProvidedHeaders);
+  final header = userProvidedHeaders == null
+      ? Headers()
+      : Headers.from(userProvidedHeaders);
   header.add(headerXGrpcWeb, "1");
   // Note that we do not support the grpc-web-text format.
   // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
@@ -54,9 +53,8 @@ Headers requestHeader(
     header[headerEncoding] = sendCompression.name;
   }
   if (acceptCompressions.isNotEmpty) {
-    header[headerAcceptEncoding] = acceptCompressions
-        .map((c) => c.name)
-        .join(",");
+    header[headerAcceptEncoding] =
+        acceptCompressions.map((c) => c.name).join(",");
   }
   return header;
 }

--- a/packages/connect/lib/src/grpc_web/response.dart
+++ b/packages/connect/lib/src/grpc_web/response.dart
@@ -32,7 +32,7 @@ extension ResponseValidation on HttpResponse {
   /// in the response header. In this case, clients can not expect a
   /// trailer.
   ({bool foundStatus, ConnectException? headerError, Compression? compression})
-      validate(StatusParser statusParser, List<Compression> acceptCompression) {
+  validate(StatusParser statusParser, List<Compression> acceptCompression) {
     // For compatibility with the `grpc-web` package, we treat all HTTP status
     // codes in the 200 range as valid, not just HTTP 200.
     if (status >= 200 && status < 300) {

--- a/packages/connect/lib/src/grpc_web/response.dart
+++ b/packages/connect/lib/src/grpc_web/response.dart
@@ -31,14 +31,8 @@ extension ResponseValidation on HttpResponse {
   /// Returns an object that indicates whether a gRPC status was found
   /// in the response header. In this case, clients can not expect a
   /// trailer.
-  ({
-    bool foundStatus,
-    ConnectException? headerError,
-    Compression? compression,
-  }) validate(
-    StatusParser statusParser,
-    List<Compression> acceptCompression,
-  ) {
+  ({bool foundStatus, ConnectException? headerError, Compression? compression})
+  validate(StatusParser statusParser, List<Compression> acceptCompression) {
     // For compatibility with the `grpc-web` package, we treat all HTTP status
     // codes in the 200 range as valid, not just HTTP 200.
     if (status >= 200 && status < 300) {

--- a/packages/connect/lib/src/grpc_web/response.dart
+++ b/packages/connect/lib/src/grpc_web/response.dart
@@ -32,7 +32,7 @@ extension ResponseValidation on HttpResponse {
   /// in the response header. In this case, clients can not expect a
   /// trailer.
   ({bool foundStatus, ConnectException? headerError, Compression? compression})
-  validate(StatusParser statusParser, List<Compression> acceptCompression) {
+      validate(StatusParser statusParser, List<Compression> acceptCompression) {
     // For compatibility with the `grpc-web` package, we treat all HTTP status
     // codes in the 200 range as valid, not just HTTP 200.
     if (status >= 200 && status < 300) {

--- a/packages/connect/lib/src/grpc_web/transport.dart
+++ b/packages/connect/lib/src/grpc_web/transport.dart
@@ -31,12 +31,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-         baseUrl,
-         codec,
-         Protocol(statusParser),
-         httpClient,
-         interceptors ?? [],
-         sendCompression,
-         acceptCompressions ?? [],
-       );
+          baseUrl,
+          codec,
+          Protocol(statusParser),
+          httpClient,
+          interceptors ?? [],
+          sendCompression,
+          acceptCompressions ?? [],
+        );
 }

--- a/packages/connect/lib/src/grpc_web/transport.dart
+++ b/packages/connect/lib/src/grpc_web/transport.dart
@@ -31,12 +31,12 @@ final class Transport extends ProtocolTransport {
     Compression? sendCompression,
     List<Compression>? acceptCompressions,
   }) : super(
-          baseUrl,
-          codec,
-          Protocol(statusParser),
-          httpClient,
-          interceptors ?? [],
-          sendCompression,
-          acceptCompressions ?? [],
-        );
+         baseUrl,
+         codec,
+         Protocol(statusParser),
+         httpClient,
+         interceptors ?? [],
+         sendCompression,
+         acceptCompressions ?? [],
+       );
 }

--- a/packages/connect/lib/src/headers.dart
+++ b/packages/connect/lib/src/headers.dart
@@ -129,10 +129,7 @@ class _Headers implements Headers {
   Iterable<String>? get(String name) {
     final values = table[name.toLowerCase()];
     if (values == null) return null;
-    return Iterable.generate(
-      values.length,
-      (i) => values[i],
-    );
+    return Iterable.generate(values.length, (i) => values[i]);
   }
 
   @override

--- a/packages/connect/lib/src/http2/connection.dart
+++ b/packages/connect/lib/src/http2/connection.dart
@@ -90,11 +90,7 @@ final class _Http2ClientTransport implements Http2ClientTransport {
     final key = '${uri.scheme}://${uri.host}:${uri.port}';
     var transport = originTransports[key];
     if (transport == null) {
-      transport = _SingleOriginHttp2ClientTransport(
-        uri,
-        context,
-        options,
-      );
+      transport = _SingleOriginHttp2ClientTransport(uri, context, options);
       originTransports[key] = transport;
     }
     return transport.makeRequest(headers);
@@ -111,11 +107,7 @@ final class _SingleOriginHttp2ClientTransport {
   _KeepAliveConnection? activeConnection;
   DateTime? lastAliveAt;
 
-  _SingleOriginHttp2ClientTransport(
-    this.uri,
-    this.context,
-    this.options,
-  );
+  _SingleOriginHttp2ClientTransport(this.uri, this.context, this.options);
 
   Future<http2.ClientTransportStream> makeRequest(
     List<http2.Header> headers,
@@ -178,10 +170,7 @@ final class _KeepAliveConnection {
   Future<bool>? verifying;
   List<http2.ClientTransportStream> streams = [];
 
-  _KeepAliveConnection(
-    this.connection,
-    this.options,
-  ) {
+  _KeepAliveConnection(this.connection, this.options) {
     resetPingTimer();
     Timer? idleTimer;
     connection.onActiveStateChanged = (active) {
@@ -205,9 +194,7 @@ final class _KeepAliveConnection {
     };
   }
 
-  http2.ClientTransportStream makeRequest(
-    List<http2.Header> headers,
-  ) {
+  http2.ClientTransportStream makeRequest(List<http2.Header> headers) {
     final stream = connection.makeRequest(headers);
     streams.add(stream);
     return stream;

--- a/packages/connect/lib/src/http2/errors.dart
+++ b/packages/connect/lib/src/http2/errors.dart
@@ -17,9 +17,7 @@ import 'package:http2/http2.dart' as http2;
 import '../code.dart';
 import '../exception.dart';
 
-ConnectException errFromRstCode(
-  int rstCode,
-) {
+ConnectException errFromRstCode(int rstCode) {
   switch (rstCode) {
     case http2.ErrorCode.NO_ERROR:
     case http2.ErrorCode.PROTOCOL_ERROR:

--- a/packages/connect/lib/src/http2/http2.dart
+++ b/packages/connect/lib/src/http2/http2.dart
@@ -45,7 +45,7 @@ HttpClient createHttpClient({Http2ClientTransport? transport}) {
         [uri.path, if (uri.hasQuery) uri.query].join("?"),
       ),
       for (final header in req.header.entries)
-        http2.Header.ascii(header.name, header.value)
+        http2.Header.ascii(header.name, header.value),
     ]);
     req.signal?.future.then((err) {
       sentinel.reject(err);
@@ -56,9 +56,7 @@ HttpClient createHttpClient({Http2ClientTransport? transport}) {
         // Ignore RST_STREAM NO_ERROR codes.
         return;
       }
-      sentinel.reject(
-        errFromRstCode(code),
-      );
+      sentinel.reject(errFromRstCode(code));
     };
     if (req.body case Stream<Uint8List> body) {
       // Write request body in parallel to the response.

--- a/packages/connect/lib/src/interceptor.dart
+++ b/packages/connect/lib/src/interceptor.dart
@@ -29,9 +29,8 @@ import 'spec.dart';
 /// To implement that layering, Interceptors are functions that wrap a call
 /// invocation. In an array of interceptors, the interceptor at the end of
 /// the array is applied first.
-typedef Interceptor = AnyFn<I, O> Function<I extends Object, O extends Object>(
-  AnyFn<I, O> next,
-);
+typedef Interceptor =
+    AnyFn<I, O> Function<I extends Object, O extends Object>(AnyFn<I, O> next);
 
 /// AnyFn represents the client-side invocation of an RPC. Interceptors can wrap
 /// this invocation, add request headers, and wrap parts of the request or
@@ -95,12 +94,7 @@ final class UnaryResponse<I, O> extends Response<I, O> {
   /// The received output message.
   final O message;
 
-  const UnaryResponse(
-    super.spec,
-    super.headers,
-    this.message,
-    super.trailers,
-  );
+  const UnaryResponse(super.spec, super.headers, this.message, super.trailers);
 }
 
 /// StreamResponse is used in interceptors to represent an ongoing call that has
@@ -109,12 +103,7 @@ final class StreamResponse<I, O> extends Response<I, O> {
   /// The output messages.
   final Stream<O> message;
 
-  const StreamResponse(
-    super.spec,
-    super.headers,
-    this.message,
-    super.trailers,
-  );
+  const StreamResponse(super.spec, super.headers, this.message, super.trailers);
 }
 
 /// StreamRequest is used in interceptors to represent a request that has

--- a/packages/connect/lib/src/interceptor.dart
+++ b/packages/connect/lib/src/interceptor.dart
@@ -29,8 +29,8 @@ import 'spec.dart';
 /// To implement that layering, Interceptors are functions that wrap a call
 /// invocation. In an array of interceptors, the interceptor at the end of
 /// the array is applied first.
-typedef Interceptor = AnyFn<I, O> Function<I extends Object, O extends Object>(
-    AnyFn<I, O> next);
+typedef Interceptor =
+    AnyFn<I, O> Function<I extends Object, O extends Object>(AnyFn<I, O> next);
 
 /// AnyFn represents the client-side invocation of an RPC. Interceptors can wrap
 /// this invocation, add request headers, and wrap parts of the request or

--- a/packages/connect/lib/src/interceptor.dart
+++ b/packages/connect/lib/src/interceptor.dart
@@ -29,8 +29,8 @@ import 'spec.dart';
 /// To implement that layering, Interceptors are functions that wrap a call
 /// invocation. In an array of interceptors, the interceptor at the end of
 /// the array is applied first.
-typedef Interceptor =
-    AnyFn<I, O> Function<I extends Object, O extends Object>(AnyFn<I, O> next);
+typedef Interceptor = AnyFn<I, O> Function<I extends Object, O extends Object>(
+    AnyFn<I, O> next);
 
 /// AnyFn represents the client-side invocation of an RPC. Interceptors can wrap
 /// this invocation, add request headers, and wrap parts of the request or

--- a/packages/connect/lib/src/protobuf.dart
+++ b/packages/connect/lib/src/protobuf.dart
@@ -29,9 +29,7 @@ final ArgumentError _invalidTypeError = ArgumentError(
 final class ProtoCodec implements StableCodec {
   final ExtensionRegistry extensionRegistry;
 
-  const ProtoCodec({
-    this.extensionRegistry = ExtensionRegistry.EMPTY,
-  });
+  const ProtoCodec({this.extensionRegistry = ExtensionRegistry.EMPTY});
 
   @override
   String get name => "proto";
@@ -85,11 +83,7 @@ final class JsonCodec implements StableCodec {
       throw _invalidTypeError;
     }
     return Utf8Encoder().convert(
-      jsonEncode(
-        message.toProto3Json(
-          typeRegistry: typeRegistry,
-        ),
-      ),
+      jsonEncode(message.toProto3Json(typeRegistry: typeRegistry)),
     );
   }
 

--- a/packages/connect/lib/src/protocol/compression.dart
+++ b/packages/connect/lib/src/protocol/compression.dart
@@ -30,9 +30,7 @@ const compressedFlag = 1; // 0b00000001
 extension EnvelopeStreamCompression on Stream<EnvelopedMessage> {
   /// Decompresses the enveloped message if the [compression] is not null and
   /// the envelope is compressed.
-  Stream<EnvelopedMessage> decompress(
-    Compression? compression,
-  ) async* {
+  Stream<EnvelopedMessage> decompress(Compression? compression) async* {
     await for (final env in this) {
       if (env.flags & compressedFlag == compressedFlag) {
         if (compression == null) {
@@ -53,9 +51,7 @@ extension EnvelopeStreamCompression on Stream<EnvelopedMessage> {
 
   /// Compresses an uncompressed enveloped message using the given
   /// [compression].
-  Stream<EnvelopedMessage> compress(
-    Compression? compression,
-  ) {
+  Stream<EnvelopedMessage> compress(Compression? compression) {
     if (compression == null) {
       return this;
     }

--- a/packages/connect/lib/src/protocol/envelope.dart
+++ b/packages/connect/lib/src/protocol/envelope.dart
@@ -72,16 +72,10 @@ extension SplitEnvelope on Stream<Uint8List> {
             headerLen += chunk.length;
             break;
           }
-          header.setAll(
-            headerLen,
-            Uint8List.sublistView(chunk, 0, needLen),
-          );
+          header.setAll(headerLen, Uint8List.sublistView(chunk, 0, needLen));
           headerLen = 5;
           final (:flags, :length) = _readHeader(headerByteData);
-          env = EnvelopedMessage(
-            flags,
-            Uint8List(length),
-          );
+          env = EnvelopedMessage(flags, Uint8List(length));
           // Reset data length and update chunk to reflect remaining data.
           dataLen = 0;
           chunk = Uint8List.sublistView(chunk, needLen);
@@ -95,10 +89,7 @@ extension SplitEnvelope on Stream<Uint8List> {
           break;
         }
         // We can complete the envelope.
-        env.data.setAll(
-          dataLen,
-          Uint8List.sublistView(chunk, 0, needLen),
-        );
+        env.data.setAll(dataLen, Uint8List.sublistView(chunk, 0, needLen));
         yield env;
         // Reset the header and chunk and continue processing.
         env = null;

--- a/packages/connect/lib/src/protocol/serialization.dart
+++ b/packages/connect/lib/src/protocol/serialization.dart
@@ -46,7 +46,7 @@ extension ParseEnvelope on Stream<EnvelopedMessage> {
   /// Parses envelopes into messages or custom end serialization.
   /// The end serialization will differ by protocol.
   Stream<ParsedEnvelopedMessage<M, E>>
-  parse<M extends Object, E extends Object>(
+      parse<M extends Object, E extends Object>(
     Codec codec,
     M Function() factory,
     int? endStreamFlag,

--- a/packages/connect/lib/src/protocol/serialization.dart
+++ b/packages/connect/lib/src/protocol/serialization.dart
@@ -29,15 +29,15 @@ import 'envelope.dart';
 sealed class ParsedEnvelopedMessage<M extends Object, E extends Object> {}
 
 /// Parsed message.
-final class ParsedMessage<M extends Object, _ extends Object>
-    implements ParsedEnvelopedMessage<M, _> {
+final class ParsedMessage<M extends Object, E extends Object>
+    implements ParsedEnvelopedMessage<M, E> {
   final M value;
   const ParsedMessage(this.value);
 }
 
 // End of stream message.
-final class EndStreamMessage<_ extends Object, E extends Object>
-    implements ParsedEnvelopedMessage<_, E> {
+final class EndStreamMessage<M extends Object, E extends Object>
+    implements ParsedEnvelopedMessage<M, E> {
   final E value;
   const EndStreamMessage(this.value);
 }
@@ -46,7 +46,7 @@ extension ParseEnvelope on Stream<EnvelopedMessage> {
   /// Parses envelopes into messages or custom end serialization.
   /// The end serialization will differ by protocol.
   Stream<ParsedEnvelopedMessage<M, E>>
-      parse<M extends Object, E extends Object>(
+  parse<M extends Object, E extends Object>(
     Codec codec,
     M Function() factory,
     int? endStreamFlag,

--- a/packages/connect/lib/src/protocol/serialization.dart
+++ b/packages/connect/lib/src/protocol/serialization.dart
@@ -46,7 +46,7 @@ extension ParseEnvelope on Stream<EnvelopedMessage> {
   /// Parses envelopes into messages or custom end serialization.
   /// The end serialization will differ by protocol.
   Stream<ParsedEnvelopedMessage<M, E>>
-      parse<M extends Object, E extends Object>(
+  parse<M extends Object, E extends Object>(
     Codec codec,
     M Function() factory,
     int? endStreamFlag,

--- a/packages/connect/lib/src/protocol/transport.dart
+++ b/packages/connect/lib/src/protocol/transport.dart
@@ -72,17 +72,15 @@ abstract base class ProtocolTransport implements Transport {
           acceptCompressions,
         );
       }
-      final first = _interceptors.apply<I, O>(
-        (req) async {
-          return await _protocol.unary(
-            req as UnaryRequest<I, O>,
-            _codec,
-            _httpClient,
-            sendCompression,
-            acceptCompressions,
-          );
-        },
-      );
+      final first = _interceptors.apply<I, O>((req) async {
+        return await _protocol.unary(
+          req as UnaryRequest<I, O>,
+          _codec,
+          _httpClient,
+          sendCompression,
+          acceptCompressions,
+        );
+      });
       return await first(req) as UnaryResponse<I, O>;
     } finally {
       // Cleanup
@@ -121,17 +119,15 @@ abstract base class ProtocolTransport implements Transport {
           acceptCompressions,
         );
       } else {
-        final first = _interceptors.apply<I, O>(
-          (req) async {
-            return await _protocol.stream(
-              req as StreamRequest<I, O>,
-              _codec,
-              _httpClient,
-              sendCompression,
-              acceptCompressions,
-            );
-          },
-        );
+        final first = _interceptors.apply<I, O>((req) async {
+          return await _protocol.stream(
+            req as StreamRequest<I, O>,
+            _codec,
+            _httpClient,
+            sendCompression,
+            acceptCompressions,
+          );
+        });
         res = await first(req) as StreamResponse<I, O>;
       }
       // We don't want to cancel the signal when this function returns
@@ -143,10 +139,7 @@ abstract base class ProtocolTransport implements Transport {
       return StreamResponse(
         res.spec,
         res.headers,
-        res.message.withHooks(
-          onError: signal.cancel,
-          onDone: signal.cancel,
-        ),
+        res.message.withHooks(onError: signal.cancel, onDone: signal.cancel),
         res.trailers,
       );
     } catch (err) {

--- a/packages/connect/lib/src/spec.dart
+++ b/packages/connect/lib/src/spec.dart
@@ -52,5 +52,5 @@ enum Idempotency {
   noSideEffects,
 
   /// Idempotent, but may have side effects.
-  idempotent
+  idempotent,
 }

--- a/packages/connect/lib/src/web.dart
+++ b/packages/connect/lib/src/web.dart
@@ -44,12 +44,10 @@ HttpClient createHttpClient({String credentials = "same-origin"}) {
     }
     final abortCtrl = web.AbortController();
     ConnectException? abortErr;
-    creq.signal?.future.then(
-      (err) {
-        abortErr = err;
-        abortCtrl.abort();
-      },
-    );
+    creq.signal?.future.then((err) {
+      abortErr = err;
+      abortCtrl.abort();
+    });
     try {
       final res = await web.fetch(
         creq.url,
@@ -95,11 +93,9 @@ HttpClient createHttpClient({String credentials = "same-origin"}) {
 extension on web.ReadableStream {
   Stream<Uint8List> toStream(AbortSignal? signal) async* {
     ConnectException? abortErr;
-    signal?.future.then(
-      (err) {
-        abortErr = err;
-      },
-    );
+    signal?.future.then((err) {
+      abortErr = err;
+    });
     final reader = getReader();
     try {
       while (true) {

--- a/packages/connect/pubspec.yaml
+++ b/packages/connect/pubspec.yaml
@@ -12,7 +12,7 @@ executables:
   protoc-gen-connect-dart:
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 resolution: workspace
 dependencies:
   protobuf: ">=3.1.0 <5.0.0"

--- a/packages/connect/test/abort_test.dart
+++ b/packages/connect/test/abort_test.dart
@@ -35,9 +35,7 @@ void main() {
     });
     test('cancels when parent cancels', () async {
       final parent = CancelableSignal();
-      final signal = CancelableSignal(
-        parent: CancelableSignal(parent: parent),
-      );
+      final signal = CancelableSignal(parent: CancelableSignal(parent: parent));
       parent.cancel();
       final ex = await signal.future;
       expect(ex.code, equals(Code.canceled));
@@ -95,10 +93,7 @@ void main() {
       final parent = CancelableSignal();
       final signal = TimeoutSignal(
         Duration(days: 1),
-        parent: TimeoutSignal(
-          Duration(days: 2),
-          parent: parent,
-        ),
+        parent: TimeoutSignal(Duration(days: 2), parent: parent),
       );
       parent.cancel();
       final ex = await signal.future;

--- a/packages/connect/test/conformance/io_test.dart
+++ b/packages/connect/test/conformance/io_test.dart
@@ -45,14 +45,14 @@ void main() {
       final codec = switch (req.codec) {
         Codec.CODEC_PROTO => ProtoCodec(),
         Codec.CODEC_JSON => JsonCodec(
-          typeRegistry: TypeRegistry([
-            UnaryRequest(),
-            ServerStreamRequest(),
-            ClientStreamRequest(),
-            BidiStreamRequest(),
-            IdempotentUnaryRequest(),
-          ]),
-        ),
+            typeRegistry: TypeRegistry([
+              UnaryRequest(),
+              ServerStreamRequest(),
+              ClientStreamRequest(),
+              BidiStreamRequest(),
+              IdempotentUnaryRequest(),
+            ]),
+          ),
         _ => throw "Unknown codec",
       };
       final context = io.SecurityContext(withTrustedRoots: false);
@@ -65,11 +65,11 @@ void main() {
       }
       final httpClient = switch (req.httpVersion) {
         HTTPVersion.HTTP_VERSION_1 => http1.createHttpClient(
-          io.HttpClient(context: context),
-        ),
+            io.HttpClient(context: context),
+          ),
         HTTPVersion.HTTP_VERSION_2 => http2.createHttpClient(
-          transport: http2.Http2ClientTransport(context: context),
-        ),
+            transport: http2.Http2ClientTransport(context: context),
+          ),
         _ => throw 'Unsupported Http version',
       };
       final compression = switch (req.compression) {
@@ -80,29 +80,29 @@ void main() {
       };
       return switch (req.protocol) {
         Protocol.PROTOCOL_CONNECT => connect.Transport(
-          baseUrl: baseUrl,
-          codec: codec,
-          httpClient: httpClient,
-          useHttpGet: req.useGetHttpMethod,
-          sendCompression: compression,
-          acceptCompressions: compression != null ? [compression] : [],
-        ),
+            baseUrl: baseUrl,
+            codec: codec,
+            httpClient: httpClient,
+            useHttpGet: req.useGetHttpMethod,
+            sendCompression: compression,
+            acceptCompressions: compression != null ? [compression] : [],
+          ),
         Protocol.PROTOCOL_GRPC => grpc.Transport(
-          baseUrl: baseUrl,
-          codec: codec,
-          httpClient: httpClient,
-          statusParser: StatusParser(),
-          sendCompression: compression,
-          acceptCompressions: compression != null ? [compression] : [],
-        ),
+            baseUrl: baseUrl,
+            codec: codec,
+            httpClient: httpClient,
+            statusParser: StatusParser(),
+            sendCompression: compression,
+            acceptCompressions: compression != null ? [compression] : [],
+          ),
         Protocol.PROTOCOL_GRPC_WEB => grpc_web.Transport(
-          baseUrl: baseUrl,
-          codec: codec,
-          httpClient: httpClient,
-          statusParser: StatusParser(),
-          sendCompression: compression,
-          acceptCompressions: compression != null ? [compression] : [],
-        ),
+            baseUrl: baseUrl,
+            codec: codec,
+            httpClient: httpClient,
+            statusParser: StatusParser(),
+            sendCompression: compression,
+            acceptCompressions: compression != null ? [compression] : [],
+          ),
         _ => throw "Unknown protocol",
       };
     },

--- a/packages/connect/test/conformance/io_test.dart
+++ b/packages/connect/test/conformance/io_test.dart
@@ -45,14 +45,14 @@ void main() {
       final codec = switch (req.codec) {
         Codec.CODEC_PROTO => ProtoCodec(),
         Codec.CODEC_JSON => JsonCodec(
-            typeRegistry: TypeRegistry([
-              UnaryRequest(),
-              ServerStreamRequest(),
-              ClientStreamRequest(),
-              BidiStreamRequest(),
-              IdempotentUnaryRequest(),
-            ]),
-          ),
+          typeRegistry: TypeRegistry([
+            UnaryRequest(),
+            ServerStreamRequest(),
+            ClientStreamRequest(),
+            BidiStreamRequest(),
+            IdempotentUnaryRequest(),
+          ]),
+        ),
         _ => throw "Unknown codec",
       };
       final context = io.SecurityContext(withTrustedRoots: false);
@@ -65,13 +65,11 @@ void main() {
       }
       final httpClient = switch (req.httpVersion) {
         HTTPVersion.HTTP_VERSION_1 => http1.createHttpClient(
-            io.HttpClient(context: context),
-          ),
+          io.HttpClient(context: context),
+        ),
         HTTPVersion.HTTP_VERSION_2 => http2.createHttpClient(
-            transport: http2.Http2ClientTransport(
-              context: context,
-            ),
-          ),
+          transport: http2.Http2ClientTransport(context: context),
+        ),
         _ => throw 'Unsupported Http version',
       };
       final compression = switch (req.compression) {
@@ -82,29 +80,29 @@ void main() {
       };
       return switch (req.protocol) {
         Protocol.PROTOCOL_CONNECT => connect.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            useHttpGet: req.useGetHttpMethod,
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          useHttpGet: req.useGetHttpMethod,
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         Protocol.PROTOCOL_GRPC => grpc.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            statusParser: StatusParser(),
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          statusParser: StatusParser(),
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         Protocol.PROTOCOL_GRPC_WEB => grpc_web.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            statusParser: StatusParser(),
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          statusParser: StatusParser(),
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         _ => throw "Unknown protocol",
       };
     },

--- a/packages/connect/test/conformance/io_test.dart
+++ b/packages/connect/test/conformance/io_test.dart
@@ -45,14 +45,14 @@ void main() {
       final codec = switch (req.codec) {
         Codec.CODEC_PROTO => ProtoCodec(),
         Codec.CODEC_JSON => JsonCodec(
-            typeRegistry: TypeRegistry([
-              UnaryRequest(),
-              ServerStreamRequest(),
-              ClientStreamRequest(),
-              BidiStreamRequest(),
-              IdempotentUnaryRequest(),
-            ]),
-          ),
+          typeRegistry: TypeRegistry([
+            UnaryRequest(),
+            ServerStreamRequest(),
+            ClientStreamRequest(),
+            BidiStreamRequest(),
+            IdempotentUnaryRequest(),
+          ]),
+        ),
         _ => throw "Unknown codec",
       };
       final context = io.SecurityContext(withTrustedRoots: false);
@@ -65,11 +65,11 @@ void main() {
       }
       final httpClient = switch (req.httpVersion) {
         HTTPVersion.HTTP_VERSION_1 => http1.createHttpClient(
-            io.HttpClient(context: context),
-          ),
+          io.HttpClient(context: context),
+        ),
         HTTPVersion.HTTP_VERSION_2 => http2.createHttpClient(
-            transport: http2.Http2ClientTransport(context: context),
-          ),
+          transport: http2.Http2ClientTransport(context: context),
+        ),
         _ => throw 'Unsupported Http version',
       };
       final compression = switch (req.compression) {
@@ -80,29 +80,29 @@ void main() {
       };
       return switch (req.protocol) {
         Protocol.PROTOCOL_CONNECT => connect.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            useHttpGet: req.useGetHttpMethod,
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          useHttpGet: req.useGetHttpMethod,
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         Protocol.PROTOCOL_GRPC => grpc.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            statusParser: StatusParser(),
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          statusParser: StatusParser(),
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         Protocol.PROTOCOL_GRPC_WEB => grpc_web.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            statusParser: StatusParser(),
-            sendCompression: compression,
-            acceptCompressions: compression != null ? [compression] : [],
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          statusParser: StatusParser(),
+          sendCompression: compression,
+          acceptCompressions: compression != null ? [compression] : [],
+        ),
         _ => throw "Unknown protocol",
       };
     },

--- a/packages/connect/test/conformance/web_test.dart
+++ b/packages/connect/test/conformance/web_test.dart
@@ -40,31 +40,31 @@ void main() {
       final codec = switch (req.codec) {
         Codec.CODEC_PROTO => ProtoCodec(),
         Codec.CODEC_JSON => JsonCodec(
-            typeRegistry: TypeRegistry([
-              UnaryRequest(),
-              ServerStreamRequest(),
-              ClientStreamRequest(),
-              BidiStreamRequest(),
-              IdempotentUnaryRequest(),
-            ]),
-          ),
+          typeRegistry: TypeRegistry([
+            UnaryRequest(),
+            ServerStreamRequest(),
+            ClientStreamRequest(),
+            BidiStreamRequest(),
+            IdempotentUnaryRequest(),
+          ]),
+        ),
         _ => throw "Unknown codec",
       };
       final httpClient = createHttpClient();
       return switch (req.protocol) {
         Protocol.PROTOCOL_GRPC => throw "unimplemented protocol",
         Protocol.PROTOCOL_CONNECT => connect.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            useHttpGet: req.useGetHttpMethod,
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          useHttpGet: req.useGetHttpMethod,
+        ),
         Protocol.PROTOCOL_GRPC_WEB => grpc_web.Transport(
-            baseUrl: baseUrl,
-            codec: codec,
-            httpClient: httpClient,
-            statusParser: StatusParser(),
-          ),
+          baseUrl: baseUrl,
+          codec: codec,
+          httpClient: httpClient,
+          statusParser: StatusParser(),
+        ),
         _ => throw "Unknown protocol",
       };
     },

--- a/packages/connect/test/conformance/web_test.dart
+++ b/packages/connect/test/conformance/web_test.dart
@@ -40,31 +40,31 @@ void main() {
       final codec = switch (req.codec) {
         Codec.CODEC_PROTO => ProtoCodec(),
         Codec.CODEC_JSON => JsonCodec(
-          typeRegistry: TypeRegistry([
-            UnaryRequest(),
-            ServerStreamRequest(),
-            ClientStreamRequest(),
-            BidiStreamRequest(),
-            IdempotentUnaryRequest(),
-          ]),
-        ),
+            typeRegistry: TypeRegistry([
+              UnaryRequest(),
+              ServerStreamRequest(),
+              ClientStreamRequest(),
+              BidiStreamRequest(),
+              IdempotentUnaryRequest(),
+            ]),
+          ),
         _ => throw "Unknown codec",
       };
       final httpClient = createHttpClient();
       return switch (req.protocol) {
         Protocol.PROTOCOL_GRPC => throw "unimplemented protocol",
         Protocol.PROTOCOL_CONNECT => connect.Transport(
-          baseUrl: baseUrl,
-          codec: codec,
-          httpClient: httpClient,
-          useHttpGet: req.useGetHttpMethod,
-        ),
+            baseUrl: baseUrl,
+            codec: codec,
+            httpClient: httpClient,
+            useHttpGet: req.useGetHttpMethod,
+          ),
         Protocol.PROTOCOL_GRPC_WEB => grpc_web.Transport(
-          baseUrl: baseUrl,
-          codec: codec,
-          httpClient: httpClient,
-          statusParser: StatusParser(),
-        ),
+            baseUrl: baseUrl,
+            codec: codec,
+            httpClient: httpClient,
+            statusParser: StatusParser(),
+          ),
         _ => throw "Unknown protocol",
       };
     },

--- a/packages/connect/test/envelope_test.dart
+++ b/packages/connect/test/envelope_test.dart
@@ -29,10 +29,7 @@ void main() {
         emitsDone,
       ]);
       test("One chunk", () {
-        expect(
-          Stream.fromIterable([envBytes]).splitEnvelope(),
-          expected,
-        );
+        expect(Stream.fromIterable([envBytes]).splitEnvelope(), expected);
       });
       test("split at header", () {
         expect(
@@ -89,10 +86,7 @@ void main() {
         );
       });
       test("Both together", () {
-        expect(
-          Stream.fromIterable([streamBytes]).splitEnvelope(),
-          expected,
-        );
+        expect(Stream.fromIterable([streamBytes]).splitEnvelope(), expected);
       });
       test("At first header", () {
         expect(
@@ -135,9 +129,8 @@ void main() {
 }
 
 class HasFlags extends CustomMatcher {
-  HasFlags(
-    EnvelopedMessage env,
-  ) : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
+  HasFlags(EnvelopedMessage env)
+    : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
 
   @override
   Object? featureValueOf(actual) {
@@ -146,9 +139,8 @@ class HasFlags extends CustomMatcher {
 }
 
 class HasData extends CustomMatcher {
-  HasData(
-    EnvelopedMessage env,
-  ) : super("EnvelopeMessage with data that is", "data", equals(env.data));
+  HasData(EnvelopedMessage env)
+    : super("EnvelopeMessage with data that is", "data", equals(env.data));
 
   @override
   Object? featureValueOf(actual) {

--- a/packages/connect/test/envelope_test.dart
+++ b/packages/connect/test/envelope_test.dart
@@ -130,7 +130,7 @@ void main() {
 
 class HasFlags extends CustomMatcher {
   HasFlags(EnvelopedMessage env)
-    : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
+      : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
 
   @override
   Object? featureValueOf(actual) {
@@ -140,7 +140,7 @@ class HasFlags extends CustomMatcher {
 
 class HasData extends CustomMatcher {
   HasData(EnvelopedMessage env)
-    : super("EnvelopeMessage with data that is", "data", equals(env.data));
+      : super("EnvelopeMessage with data that is", "data", equals(env.data));
 
   @override
   Object? featureValueOf(actual) {

--- a/packages/connect/test/envelope_test.dart
+++ b/packages/connect/test/envelope_test.dart
@@ -130,7 +130,7 @@ void main() {
 
 class HasFlags extends CustomMatcher {
   HasFlags(EnvelopedMessage env)
-      : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
+    : super("EnvelopeMessage with flags that is", "flags", equals(env.flags));
 
   @override
   Object? featureValueOf(actual) {
@@ -140,7 +140,7 @@ class HasFlags extends CustomMatcher {
 
 class HasData extends CustomMatcher {
   HasData(EnvelopedMessage env)
-      : super("EnvelopeMessage with data that is", "data", equals(env.data));
+    : super("EnvelopeMessage with data that is", "data", equals(env.data));
 
   @override
   Object? featureValueOf(actual) {

--- a/packages/connect/test/fake_test.dart
+++ b/packages/connect/test/fake_test.dart
@@ -53,29 +53,28 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().unary(
-        TestService.unary,
-        (req, context) {
-          expect(req.value, equals("foo"));
-          expect(context.requestHeaders['foo'], equals('bar'));
-          context.responseHeaders.add('bar', 'foo');
-          context.responseTrailers.add('baz', 'foo');
-          return StringValue(value: "bar");
-        },
-      ).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              expect(res.trailers['baz'], 'foo');
-              return res;
-            };
-          }
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .unary(TestService.unary, (req, context) {
+            expect(req.value, equals("foo"));
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            return StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  expect(res.trailers['baz'], 'foo');
+                  return res;
+                };
+              },
+            ],
+          );
       final res = await Client(transport).unary(
         TestService.unary,
         StringValue(value: "foo"),
@@ -98,45 +97,42 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().client(
-        TestService.clientStream,
-        (req, context) async {
-          await for (final next in req) {
-            expect(next.value, equals("foo"));
-          }
-          expect(context.requestHeaders['foo'], equals('bar'));
-          context.responseHeaders.add('bar', 'foo');
-          context.responseTrailers.add('baz', 'foo');
-          return StringValue(value: "bar");
-        },
-      ).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind(
-                    (stream) async* {
-                      yield* stream;
-                      expect(res.trailers['baz'], 'foo');
-                    },
-                  ),
-                ),
-                res.trailers,
-              );
-            };
-          }
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .client(TestService.clientStream, (req, context) async {
+            await for (final next in req) {
+              expect(next.value, equals("foo"));
+            }
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            return StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = await Client(transport).client(
         TestService.clientStream,
         Stream.fromIterable([StringValue(value: "foo")]),
@@ -159,43 +155,40 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().server(
-        TestService.serverStream,
-        (req, context) async* {
-          expect(req.value, equals("foo"));
-          expect(context.requestHeaders['foo'], equals('bar'));
-          context.responseHeaders.add('bar', 'foo');
-          context.responseTrailers.add('baz', 'foo');
-          yield StringValue(value: "bar");
-        },
-      ).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind(
-                    (stream) async* {
-                      yield* stream;
-                      expect(res.trailers['baz'], 'foo');
-                    },
-                  ),
-                ),
-                res.trailers,
-              );
-            };
-          }
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .server(TestService.serverStream, (req, context) async* {
+            expect(req.value, equals("foo"));
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            yield StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = Client(transport).server(
         TestService.serverStream,
         StringValue(value: "foo"),
@@ -220,45 +213,42 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().bidi(
-        TestService.bidiStream,
-        (req, context) async* {
-          await for (final next in req) {
-            expect(next.value, equals('foo'));
-          }
-          expect(context.requestHeaders['foo'], equals('bar'));
-          context.responseHeaders.add('bar', 'foo');
-          context.responseTrailers.add('baz', 'foo');
-          yield StringValue(value: "bar");
-        },
-      ).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind(
-                    (stream) async* {
-                      yield* stream;
-                      expect(res.trailers['baz'], 'foo');
-                    },
-                  ),
-                ),
-                res.trailers,
-              );
-            };
-          }
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .bidi(TestService.bidiStream, (req, context) async* {
+            await for (final next in req) {
+              expect(next.value, equals('foo'));
+            }
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            yield StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = Client(transport).bidi(
         TestService.bidiStream,
         Stream.fromIterable([StringValue(value: "foo")]),

--- a/packages/connect/test/fake_test.dart
+++ b/packages/connect/test/fake_test.dart
@@ -53,28 +53,27 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder()
-          .unary(TestService.unary, (req, context) {
-            expect(req.value, equals("foo"));
-            expect(context.requestHeaders['foo'], equals('bar'));
-            context.responseHeaders.add('bar', 'foo');
-            context.responseTrailers.add('baz', 'foo');
-            return StringValue(value: "bar");
-          })
-          .build(
-            interceptors: [
-              <I extends Object, O extends Object>(next) {
-                return (req) async {
-                  interceptor = true;
-                  expect(req.headers['foo'], equals('bar'));
-                  final res = await next(req);
-                  expect(res.headers['bar'], 'foo');
-                  expect(res.trailers['baz'], 'foo');
-                  return res;
-                };
-              },
-            ],
-          );
+      final transport =
+          FakeTransportBuilder().unary(TestService.unary, (req, context) {
+        expect(req.value, equals("foo"));
+        expect(context.requestHeaders['foo'], equals('bar'));
+        context.responseHeaders.add('bar', 'foo');
+        context.responseTrailers.add('baz', 'foo');
+        return StringValue(value: "bar");
+      }).build(
+        interceptors: [
+          <I extends Object, O extends Object>(next) {
+            return (req) async {
+              interceptor = true;
+              expect(req.headers['foo'], equals('bar'));
+              final res = await next(req);
+              expect(res.headers['bar'], 'foo');
+              expect(res.trailers['baz'], 'foo');
+              return res;
+            };
+          },
+        ],
+      );
       final res = await Client(transport).unary(
         TestService.unary,
         StringValue(value: "foo"),
@@ -97,42 +96,41 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder()
-          .client(TestService.clientStream, (req, context) async {
-            await for (final next in req) {
-              expect(next.value, equals("foo"));
-            }
-            expect(context.requestHeaders['foo'], equals('bar'));
-            context.responseHeaders.add('bar', 'foo');
-            context.responseTrailers.add('baz', 'foo');
-            return StringValue(value: "bar");
-          })
-          .build(
-            interceptors: [
-              <I extends Object, O extends Object>(next) {
-                return (req) async {
-                  interceptor = true;
-                  expect(req.headers['foo'], equals('bar'));
-                  final res = await next(req);
-                  expect(res.headers['bar'], 'foo');
-                  // Trailers are only visible after the last received message
-                  expect(res.trailers['baz'], null);
-                  expect(res, isA<StreamResponse<I, O>>());
-                  return StreamResponse(
-                    res.spec,
-                    res.headers,
-                    (res as StreamResponse<I, O>).message.transform(
-                      StreamTransformer.fromBind((stream) async* {
-                        yield* stream;
-                        expect(res.trailers['baz'], 'foo');
-                      }),
-                    ),
-                    res.trailers,
-                  );
-                };
-              },
-            ],
-          );
+      final transport = FakeTransportBuilder().client(TestService.clientStream,
+          (req, context) async {
+        await for (final next in req) {
+          expect(next.value, equals("foo"));
+        }
+        expect(context.requestHeaders['foo'], equals('bar'));
+        context.responseHeaders.add('bar', 'foo');
+        context.responseTrailers.add('baz', 'foo');
+        return StringValue(value: "bar");
+      }).build(
+        interceptors: [
+          <I extends Object, O extends Object>(next) {
+            return (req) async {
+              interceptor = true;
+              expect(req.headers['foo'], equals('bar'));
+              final res = await next(req);
+              expect(res.headers['bar'], 'foo');
+              // Trailers are only visible after the last received message
+              expect(res.trailers['baz'], null);
+              expect(res, isA<StreamResponse<I, O>>());
+              return StreamResponse(
+                res.spec,
+                res.headers,
+                (res as StreamResponse<I, O>).message.transform(
+                  StreamTransformer.fromBind((stream) async* {
+                    yield* stream;
+                    expect(res.trailers['baz'], 'foo');
+                  }),
+                ),
+                res.trailers,
+              );
+            };
+          },
+        ],
+      );
       final res = await Client(transport).client(
         TestService.clientStream,
         Stream.fromIterable([StringValue(value: "foo")]),
@@ -155,40 +153,39 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder()
-          .server(TestService.serverStream, (req, context) async* {
-            expect(req.value, equals("foo"));
-            expect(context.requestHeaders['foo'], equals('bar'));
-            context.responseHeaders.add('bar', 'foo');
-            context.responseTrailers.add('baz', 'foo');
-            yield StringValue(value: "bar");
-          })
-          .build(
-            interceptors: [
-              <I extends Object, O extends Object>(next) {
-                return (req) async {
-                  interceptor = true;
-                  expect(req.headers['foo'], equals('bar'));
-                  final res = await next(req);
-                  expect(res.headers['bar'], 'foo');
-                  // Trailers are only visible after the last received message
-                  expect(res.trailers['baz'], null);
-                  expect(res, isA<StreamResponse<I, O>>());
-                  return StreamResponse(
-                    res.spec,
-                    res.headers,
-                    (res as StreamResponse<I, O>).message.transform(
-                      StreamTransformer.fromBind((stream) async* {
-                        yield* stream;
-                        expect(res.trailers['baz'], 'foo');
-                      }),
-                    ),
-                    res.trailers,
-                  );
-                };
-              },
-            ],
-          );
+      final transport = FakeTransportBuilder().server(TestService.serverStream,
+          (req, context) async* {
+        expect(req.value, equals("foo"));
+        expect(context.requestHeaders['foo'], equals('bar'));
+        context.responseHeaders.add('bar', 'foo');
+        context.responseTrailers.add('baz', 'foo');
+        yield StringValue(value: "bar");
+      }).build(
+        interceptors: [
+          <I extends Object, O extends Object>(next) {
+            return (req) async {
+              interceptor = true;
+              expect(req.headers['foo'], equals('bar'));
+              final res = await next(req);
+              expect(res.headers['bar'], 'foo');
+              // Trailers are only visible after the last received message
+              expect(res.trailers['baz'], null);
+              expect(res, isA<StreamResponse<I, O>>());
+              return StreamResponse(
+                res.spec,
+                res.headers,
+                (res as StreamResponse<I, O>).message.transform(
+                  StreamTransformer.fromBind((stream) async* {
+                    yield* stream;
+                    expect(res.trailers['baz'], 'foo');
+                  }),
+                ),
+                res.trailers,
+              );
+            };
+          },
+        ],
+      );
       final res = Client(transport).server(
         TestService.serverStream,
         StringValue(value: "foo"),
@@ -213,42 +210,41 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder()
-          .bidi(TestService.bidiStream, (req, context) async* {
-            await for (final next in req) {
-              expect(next.value, equals('foo'));
-            }
-            expect(context.requestHeaders['foo'], equals('bar'));
-            context.responseHeaders.add('bar', 'foo');
-            context.responseTrailers.add('baz', 'foo');
-            yield StringValue(value: "bar");
-          })
-          .build(
-            interceptors: [
-              <I extends Object, O extends Object>(next) {
-                return (req) async {
-                  interceptor = true;
-                  expect(req.headers['foo'], equals('bar'));
-                  final res = await next(req);
-                  expect(res.headers['bar'], 'foo');
-                  // Trailers are only visible after the last received message
-                  expect(res.trailers['baz'], null);
-                  expect(res, isA<StreamResponse<I, O>>());
-                  return StreamResponse(
-                    res.spec,
-                    res.headers,
-                    (res as StreamResponse<I, O>).message.transform(
-                      StreamTransformer.fromBind((stream) async* {
-                        yield* stream;
-                        expect(res.trailers['baz'], 'foo');
-                      }),
-                    ),
-                    res.trailers,
-                  );
-                };
-              },
-            ],
-          );
+      final transport = FakeTransportBuilder().bidi(TestService.bidiStream,
+          (req, context) async* {
+        await for (final next in req) {
+          expect(next.value, equals('foo'));
+        }
+        expect(context.requestHeaders['foo'], equals('bar'));
+        context.responseHeaders.add('bar', 'foo');
+        context.responseTrailers.add('baz', 'foo');
+        yield StringValue(value: "bar");
+      }).build(
+        interceptors: [
+          <I extends Object, O extends Object>(next) {
+            return (req) async {
+              interceptor = true;
+              expect(req.headers['foo'], equals('bar'));
+              final res = await next(req);
+              expect(res.headers['bar'], 'foo');
+              // Trailers are only visible after the last received message
+              expect(res.trailers['baz'], null);
+              expect(res, isA<StreamResponse<I, O>>());
+              return StreamResponse(
+                res.spec,
+                res.headers,
+                (res as StreamResponse<I, O>).message.transform(
+                  StreamTransformer.fromBind((stream) async* {
+                    yield* stream;
+                    expect(res.trailers['baz'], 'foo');
+                  }),
+                ),
+                res.trailers,
+              );
+            };
+          },
+        ],
+      );
       final res = Client(transport).bidi(
         TestService.bidiStream,
         Stream.fromIterable([StringValue(value: "foo")]),

--- a/packages/connect/test/fake_test.dart
+++ b/packages/connect/test/fake_test.dart
@@ -53,27 +53,28 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport =
-          FakeTransportBuilder().unary(TestService.unary, (req, context) {
-        expect(req.value, equals("foo"));
-        expect(context.requestHeaders['foo'], equals('bar'));
-        context.responseHeaders.add('bar', 'foo');
-        context.responseTrailers.add('baz', 'foo');
-        return StringValue(value: "bar");
-      }).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              expect(res.trailers['baz'], 'foo');
-              return res;
-            };
-          },
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .unary(TestService.unary, (req, context) {
+            expect(req.value, equals("foo"));
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            return StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  expect(res.trailers['baz'], 'foo');
+                  return res;
+                };
+              },
+            ],
+          );
       final res = await Client(transport).unary(
         TestService.unary,
         StringValue(value: "foo"),
@@ -96,41 +97,42 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().client(TestService.clientStream,
-          (req, context) async {
-        await for (final next in req) {
-          expect(next.value, equals("foo"));
-        }
-        expect(context.requestHeaders['foo'], equals('bar'));
-        context.responseHeaders.add('bar', 'foo');
-        context.responseTrailers.add('baz', 'foo');
-        return StringValue(value: "bar");
-      }).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind((stream) async* {
-                    yield* stream;
-                    expect(res.trailers['baz'], 'foo');
-                  }),
-                ),
-                res.trailers,
-              );
-            };
-          },
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .client(TestService.clientStream, (req, context) async {
+            await for (final next in req) {
+              expect(next.value, equals("foo"));
+            }
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            return StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = await Client(transport).client(
         TestService.clientStream,
         Stream.fromIterable([StringValue(value: "foo")]),
@@ -153,39 +155,40 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().server(TestService.serverStream,
-          (req, context) async* {
-        expect(req.value, equals("foo"));
-        expect(context.requestHeaders['foo'], equals('bar'));
-        context.responseHeaders.add('bar', 'foo');
-        context.responseTrailers.add('baz', 'foo');
-        yield StringValue(value: "bar");
-      }).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind((stream) async* {
-                    yield* stream;
-                    expect(res.trailers['baz'], 'foo');
-                  }),
-                ),
-                res.trailers,
-              );
-            };
-          },
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .server(TestService.serverStream, (req, context) async* {
+            expect(req.value, equals("foo"));
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            yield StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = Client(transport).server(
         TestService.serverStream,
         StringValue(value: "foo"),
@@ -210,41 +213,42 @@ void main() {
       var interceptor = false;
       var onHeader = false;
       var onTrailer = false;
-      final transport = FakeTransportBuilder().bidi(TestService.bidiStream,
-          (req, context) async* {
-        await for (final next in req) {
-          expect(next.value, equals('foo'));
-        }
-        expect(context.requestHeaders['foo'], equals('bar'));
-        context.responseHeaders.add('bar', 'foo');
-        context.responseTrailers.add('baz', 'foo');
-        yield StringValue(value: "bar");
-      }).build(
-        interceptors: [
-          <I extends Object, O extends Object>(next) {
-            return (req) async {
-              interceptor = true;
-              expect(req.headers['foo'], equals('bar'));
-              final res = await next(req);
-              expect(res.headers['bar'], 'foo');
-              // Trailers are only visible after the last received message
-              expect(res.trailers['baz'], null);
-              expect(res, isA<StreamResponse<I, O>>());
-              return StreamResponse(
-                res.spec,
-                res.headers,
-                (res as StreamResponse<I, O>).message.transform(
-                  StreamTransformer.fromBind((stream) async* {
-                    yield* stream;
-                    expect(res.trailers['baz'], 'foo');
-                  }),
-                ),
-                res.trailers,
-              );
-            };
-          },
-        ],
-      );
+      final transport = FakeTransportBuilder()
+          .bidi(TestService.bidiStream, (req, context) async* {
+            await for (final next in req) {
+              expect(next.value, equals('foo'));
+            }
+            expect(context.requestHeaders['foo'], equals('bar'));
+            context.responseHeaders.add('bar', 'foo');
+            context.responseTrailers.add('baz', 'foo');
+            yield StringValue(value: "bar");
+          })
+          .build(
+            interceptors: [
+              <I extends Object, O extends Object>(next) {
+                return (req) async {
+                  interceptor = true;
+                  expect(req.headers['foo'], equals('bar'));
+                  final res = await next(req);
+                  expect(res.headers['bar'], 'foo');
+                  // Trailers are only visible after the last received message
+                  expect(res.trailers['baz'], null);
+                  expect(res, isA<StreamResponse<I, O>>());
+                  return StreamResponse(
+                    res.spec,
+                    res.headers,
+                    (res as StreamResponse<I, O>).message.transform(
+                      StreamTransformer.fromBind((stream) async* {
+                        yield* stream;
+                        expect(res.trailers['baz'], 'foo');
+                      }),
+                    ),
+                    res.trailers,
+                  );
+                };
+              },
+            ],
+          );
       final res = Client(transport).bidi(
         TestService.bidiStream,
         Stream.fromIterable([StringValue(value: "foo")]),

--- a/packages/connect/test/http2_test.dart
+++ b/packages/connect/test/http2_test.dart
@@ -29,10 +29,7 @@ void main() {
   List<http2.ServerTransportStream> serverStreams = [];
   List<int> serverPings = [];
   setUp(() async {
-    serverSocket = await ServerSocket.bind(
-      InternetAddress.loopbackIPv4,
-      0,
-    );
+    serverSocket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     serverSocket.listen(
       (socket) {
         final conn = http2.ServerTransportConnection.viaSocket(socket);
@@ -119,21 +116,15 @@ void main() {
         expect(serverPings.length, greaterThanOrEqualTo(1));
         await req.close();
       });
-      test(
-        'should destroy the connection if not answered in time',
-        () async {
-          final transport = Http2ClientTransport(
-            pingTimeout: Duration.zero,
-            pingInterval: Duration(milliseconds: 5),
-          );
-          final req = await transport.request(uri);
-          expect(
-            req.incomingMessages,
-            emitsError(anything),
-          );
-          req.terminate();
-        },
-      );
+      test('should destroy the connection if not answered in time', () async {
+        final transport = Http2ClientTransport(
+          pingTimeout: Duration.zero,
+          pingInterval: Duration(milliseconds: 5),
+        );
+        final req = await transport.request(uri);
+        expect(req.incomingMessages, emitsError(anything));
+        req.terminate();
+      });
     });
     group('for idle connections', () {
       test('should not be sent by default', () async {

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -135,12 +135,12 @@ class GeneratedFilesMatcher extends Matcher {
   final bool replace;
 
   GeneratedFilesMatcher(List<String> files, this.replace)
-      : files = Map.fromEntries(
-          files.map(
-            (path) => MapEntry(
-                "$path.dart", File(p.join("test/plugin/golden", path))),
-          ),
-        );
+    : files = Map.fromEntries(
+        files.map(
+          (path) =>
+              MapEntry("$path.dart", File(p.join("test/plugin/golden", path))),
+        ),
+      );
 
   @override
   // ignore: strict_raw_type

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -135,12 +135,12 @@ class GeneratedFilesMatcher extends Matcher {
   final bool replace;
 
   GeneratedFilesMatcher(List<String> files, this.replace)
-    : files = Map.fromEntries(
-        files.map(
-          (path) =>
-              MapEntry("$path.dart", File(p.join("test/plugin/golden", path))),
-        ),
-      );
+      : files = Map.fromEntries(
+          files.map(
+            (path) => MapEntry(
+                "$path.dart", File(p.join("test/plugin/golden", path))),
+          ),
+        );
 
   @override
   // ignore: strict_raw_type

--- a/packages/connect/test/plugin/plugin_test.dart
+++ b/packages/connect/test/plugin/plugin_test.dart
@@ -31,17 +31,16 @@ void main() async {
   test('generating all rpc types with protos in the same file', () async {
     expect(
       await runPlugin(image, "foo/v1/foo.proto"),
-      matchGenerated(
-        ['foo/v1/foo.connect.client', 'foo/v1/foo.connect.spec'],
-      ),
+      matchGenerated(['foo/v1/foo.connect.client', 'foo/v1/foo.connect.spec']),
     );
   });
   test('generating with request in a different proto file', () async {
     expect(
       await runPlugin(image, "bar/bar_service.proto"),
-      matchGenerated(
-        ['bar/bar_service.connect.client', 'bar/bar_service.connect.spec'],
-      ),
+      matchGenerated([
+        'bar/bar_service.connect.client',
+        'bar/bar_service.connect.spec',
+      ]),
     );
   });
   test('skips empty file', () async {
@@ -51,41 +50,34 @@ void main() async {
   test('generate empty file with keep_empty_files', () async {
     expect(
       await runPlugin(image, "bar/bar.proto", paramter: "keep_empty_files"),
-      matchGenerated(
-        ['bar/bar.connect.client', 'bar/bar.connect.spec'],
-      ),
+      matchGenerated(['bar/bar.connect.client', 'bar/bar.connect.spec']),
     );
   });
   test('generates well-known-types as request/response', () async {
     expect(
       await runPlugin(image, "wkt.proto"),
-      matchGenerated(
-        ['wkt.connect.client', 'wkt.connect.spec'],
-      ),
+      matchGenerated(['wkt.connect.client', 'wkt.connect.spec']),
     );
   });
   test('generates for keywords', () async {
     expect(
       await runPlugin(image, "dart.proto"),
-      matchGenerated(
-        ['dart.connect.client', 'dart.connect.spec'],
-      ),
+      matchGenerated(['dart.connect.client', 'dart.connect.spec']),
     );
   });
   test('generates with conflicting imports', () async {
     expect(
       await runPlugin(image, "connect.proto"),
-      matchGenerated(
-        ['connect.connect.client', 'connect.connect.spec'],
-      ),
+      matchGenerated(['connect.connect.client', 'connect.connect.spec']),
     );
   });
   test('generates idempotency option', () async {
     expect(
       await runPlugin(image, "idempotency.proto"),
-      matchGenerated(
-        ['idempotency.connect.client', 'idempotency.connect.spec'],
-      ),
+      matchGenerated([
+        'idempotency.connect.client',
+        'idempotency.connect.spec',
+      ]),
     );
   });
 }
@@ -104,25 +96,20 @@ Future<CodeGeneratorResponse> runPlugin(
   final buffer = StreamController<List<int>>();
   await run(Stream.fromIterable([req.writeToBuffer()]), buffer);
   return CodeGeneratorResponse.fromBuffer(
-    (await buffer.stream.toList()).reduce(
-      ((v, e) => v + e),
-    ),
+    (await buffer.stream.toList()).reduce(((v, e) => v + e)),
   );
 }
 
 Future<FileDescriptorSet> buildTestImage() async {
-  final result = Process.runSync(
-    'dart',
-    [
-      'run',
-      'tools:buf',
-      'build',
-      '--as-file-descriptor-set',
-      'test/plugin/proto',
-      '-o',
-      '-#format=json'
-    ],
-  );
+  final result = Process.runSync('dart', [
+    'run',
+    'tools:buf',
+    'build',
+    '--as-file-descriptor-set',
+    'test/plugin/proto',
+    '-o',
+    '-#format=json',
+  ]);
   return FileDescriptorSet()
     ..mergeFromProto3Json(jsonDecode(result.stdout as String));
 }
@@ -138,10 +125,7 @@ GeneratedFilesMatcher matchGenerated(
   List<String> files, [
   bool replace = false,
 ]) {
-  return GeneratedFilesMatcher(
-    files,
-    replace,
-  );
+  return GeneratedFilesMatcher(files, replace);
 }
 
 class GeneratedFilesMatcher extends Matcher {
@@ -150,17 +134,13 @@ class GeneratedFilesMatcher extends Matcher {
   /// Whether to replace before checking. Usefule to populate first runs.
   final bool replace;
 
-  GeneratedFilesMatcher(
-    List<String> files,
-    this.replace,
-  ) : files = Map.fromEntries(
-          files.map(
-            (path) => MapEntry(
-              "$path.dart",
-              File(p.join("test/plugin/golden", path)),
-            ),
-          ),
-        );
+  GeneratedFilesMatcher(List<String> files, this.replace)
+    : files = Map.fromEntries(
+        files.map(
+          (path) =>
+              MapEntry("$path.dart", File(p.join("test/plugin/golden", path))),
+        ),
+      );
 
   @override
   // ignore: strict_raw_type
@@ -215,20 +195,15 @@ class GeneratedFilesMatcher extends Matcher {
     for (final file in item.file) {
       final golden = files[file.name];
       if (golden == null) {
-        description.add(
-          'Unexpected file ${file.name} generated',
-        );
+        description.add('Unexpected file ${file.name} generated');
         continue;
       }
       final goldenContent = golden.readAsStringSync();
       if (goldenContent != file.content) {
         // Reusing the equals matcher gives us a passable diff
-        equals(goldenContent).describeMismatch(
-          file.content,
-          description,
-          matchState,
-          verbose,
-        );
+        equals(
+          goldenContent,
+        ).describeMismatch(file.content, description, matchState, verbose);
       }
     }
     return description;

--- a/packages/connect/test/protocol/transport_test.dart
+++ b/packages/connect/test/protocol/transport_test.dart
@@ -57,18 +57,16 @@ void main() {
             onRequestHeaders: <I, O>(spec, codec, options) {
               return Headers()..add('foo', 'bar');
             },
-            onUnary: <I, O>(req) async => UnaryResponse(
-              req.spec,
-              Headers(),
-              req.message as O,
-              Headers(),
-            ),
+            onUnary:
+                <I, O>(req) async => UnaryResponse(
+                  req.spec,
+                  Headers(),
+                  req.message as O,
+                  Headers(),
+                ),
           ),
         );
-        await transport.unary(
-          TestService.unary,
-          StringValue(value: "foo"),
-        );
+        await transport.unary(TestService.unary, StringValue(value: "foo"));
       });
       test('must apply like an onion', () async {
         /// Returns an interceptor that sets a header on both request and response.
@@ -84,10 +82,7 @@ void main() {
         }
 
         final transport = TestTransport(
-          interceptors: [
-            setHeader("key", "1"),
-            setHeader("key", "2"),
-          ],
+          interceptors: [setHeader("key", "1"), setHeader("key", "2")],
           protocol: DelegatingProtocol(
             onUnary: <I, O>(req) async {
               // Must see the later value
@@ -111,21 +106,19 @@ void main() {
       test('should be able to cast to unary types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onUnary: <I, O>(req) async => UnaryResponse(
-              req.spec,
-              Headers(),
-              req.message as O,
-              Headers(),
-            ),
+            onUnary:
+                <I, O>(req) async => UnaryResponse(
+                  req.spec,
+                  Headers(),
+                  req.message as O,
+                  Headers(),
+                ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
               return (req) async {
                 expect(req, isA<UnaryRequest<I, O>>());
-                expect(
-                  (req as UnaryRequest<I, O>).message,
-                  isA<StringValue>(),
-                );
+                expect((req as UnaryRequest<I, O>).message, isA<StringValue>());
                 final res = await next(req);
                 expect(res, isA<UnaryResponse<I, O>>());
                 expect(
@@ -134,23 +127,21 @@ void main() {
                 );
                 return res;
               };
-            }
+            },
           ],
         );
-        await transport.unary(
-          TestService.unary,
-          StringValue(value: "foo"),
-        );
+        await transport.unary(TestService.unary, StringValue(value: "foo"));
       });
       test('should be able to cast to stream types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onStream: <I, O>(req) async => StreamResponse(
-              req.spec,
-              Headers(),
-              req.message.cast<O>(),
-              Headers(),
-            ),
+            onStream:
+                <I, O>(req) async => StreamResponse(
+                  req.spec,
+                  Headers(),
+                  req.message.cast<O>(),
+                  Headers(),
+                ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
@@ -168,7 +159,7 @@ void main() {
                 );
                 return res;
               };
-            }
+            },
           ],
         );
         await transport.stream(
@@ -182,15 +173,11 @@ void main() {
 
 class DelegatingProtocol implements Protocol {
   final Headers Function<I, O>(Spec<I, O>, Codec, CallOptions?)?
-      onRequestHeaders;
+  onRequestHeaders;
   final Future<StreamResponse<I, O>> Function<I, O>(StreamRequest<I, O>)?
-      onStream;
+  onStream;
   final Future<UnaryResponse<I, O>> Function<I, O>(UnaryRequest<I, O>)? onUnary;
-  DelegatingProtocol({
-    this.onUnary,
-    this.onStream,
-    this.onRequestHeaders,
-  });
+  DelegatingProtocol({this.onUnary, this.onStream, this.onRequestHeaders});
 
   @override
   Headers requestHeaders<I, O>(
@@ -202,11 +189,7 @@ class DelegatingProtocol implements Protocol {
   ) {
     final onRequestHeaders = this.onRequestHeaders;
     if (onRequestHeaders != null) {
-      return onRequestHeaders(
-        spec,
-        codec,
-        options,
-      );
+      return onRequestHeaders(spec, codec, options);
     }
     return options?.headers ?? Headers();
   }
@@ -222,12 +205,7 @@ class DelegatingProtocol implements Protocol {
     final onUnary = this.onUnary;
     if (onUnary != null) {
       final res = await onUnary(req);
-      return UnaryResponse(
-        req.spec,
-        res.headers,
-        res.message,
-        res.trailers,
-      );
+      return UnaryResponse(req.spec, res.headers, res.message, res.trailers);
     }
     throw UnimplementedError();
   }
@@ -255,18 +233,16 @@ class DelegatingProtocol implements Protocol {
 }
 
 final class TestTransport extends ProtocolTransport {
-  TestTransport({
-    required Protocol protocol,
-    List<Interceptor>? interceptors,
-  }) : super(
-          "https://test",
-          ProtoCodec(),
-          protocol,
-          (req) => throw UnimplementedError(),
-          interceptors ?? [],
-          null,
-          [],
-        );
+  TestTransport({required Protocol protocol, List<Interceptor>? interceptors})
+    : super(
+        "https://test",
+        ProtoCodec(),
+        protocol,
+        (req) => throw UnimplementedError(),
+        interceptors ?? [],
+        null,
+        [],
+      );
 }
 
 final class ClassInterceptor {

--- a/packages/connect/test/protocol/transport_test.dart
+++ b/packages/connect/test/protocol/transport_test.dart
@@ -57,13 +57,12 @@ void main() {
             onRequestHeaders: <I, O>(spec, codec, options) {
               return Headers()..add('foo', 'bar');
             },
-            onUnary:
-                <I, O>(req) async => UnaryResponse(
-                  req.spec,
-                  Headers(),
-                  req.message as O,
-                  Headers(),
-                ),
+            onUnary: <I, O>(req) async => UnaryResponse(
+              req.spec,
+              Headers(),
+              req.message as O,
+              Headers(),
+            ),
           ),
         );
         await transport.unary(TestService.unary, StringValue(value: "foo"));
@@ -106,13 +105,12 @@ void main() {
       test('should be able to cast to unary types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onUnary:
-                <I, O>(req) async => UnaryResponse(
-                  req.spec,
-                  Headers(),
-                  req.message as O,
-                  Headers(),
-                ),
+            onUnary: <I, O>(req) async => UnaryResponse(
+              req.spec,
+              Headers(),
+              req.message as O,
+              Headers(),
+            ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
@@ -135,13 +133,12 @@ void main() {
       test('should be able to cast to stream types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onStream:
-                <I, O>(req) async => StreamResponse(
-                  req.spec,
-                  Headers(),
-                  req.message.cast<O>(),
-                  Headers(),
-                ),
+            onStream: <I, O>(req) async => StreamResponse(
+              req.spec,
+              Headers(),
+              req.message.cast<O>(),
+              Headers(),
+            ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
@@ -173,9 +170,9 @@ void main() {
 
 class DelegatingProtocol implements Protocol {
   final Headers Function<I, O>(Spec<I, O>, Codec, CallOptions?)?
-  onRequestHeaders;
+      onRequestHeaders;
   final Future<StreamResponse<I, O>> Function<I, O>(StreamRequest<I, O>)?
-  onStream;
+      onStream;
   final Future<UnaryResponse<I, O>> Function<I, O>(UnaryRequest<I, O>)? onUnary;
   DelegatingProtocol({this.onUnary, this.onStream, this.onRequestHeaders});
 
@@ -234,15 +231,15 @@ class DelegatingProtocol implements Protocol {
 
 final class TestTransport extends ProtocolTransport {
   TestTransport({required Protocol protocol, List<Interceptor>? interceptors})
-    : super(
-        "https://test",
-        ProtoCodec(),
-        protocol,
-        (req) => throw UnimplementedError(),
-        interceptors ?? [],
-        null,
-        [],
-      );
+      : super(
+          "https://test",
+          ProtoCodec(),
+          protocol,
+          (req) => throw UnimplementedError(),
+          interceptors ?? [],
+          null,
+          [],
+        );
 }
 
 final class ClassInterceptor {

--- a/packages/connect/test/protocol/transport_test.dart
+++ b/packages/connect/test/protocol/transport_test.dart
@@ -57,12 +57,13 @@ void main() {
             onRequestHeaders: <I, O>(spec, codec, options) {
               return Headers()..add('foo', 'bar');
             },
-            onUnary: <I, O>(req) async => UnaryResponse(
-              req.spec,
-              Headers(),
-              req.message as O,
-              Headers(),
-            ),
+            onUnary:
+                <I, O>(req) async => UnaryResponse(
+                  req.spec,
+                  Headers(),
+                  req.message as O,
+                  Headers(),
+                ),
           ),
         );
         await transport.unary(TestService.unary, StringValue(value: "foo"));
@@ -105,12 +106,13 @@ void main() {
       test('should be able to cast to unary types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onUnary: <I, O>(req) async => UnaryResponse(
-              req.spec,
-              Headers(),
-              req.message as O,
-              Headers(),
-            ),
+            onUnary:
+                <I, O>(req) async => UnaryResponse(
+                  req.spec,
+                  Headers(),
+                  req.message as O,
+                  Headers(),
+                ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
@@ -133,12 +135,13 @@ void main() {
       test('should be able to cast to stream types', () async {
         final transport = TestTransport(
           protocol: DelegatingProtocol(
-            onStream: <I, O>(req) async => StreamResponse(
-              req.spec,
-              Headers(),
-              req.message.cast<O>(),
-              Headers(),
-            ),
+            onStream:
+                <I, O>(req) async => StreamResponse(
+                  req.spec,
+                  Headers(),
+                  req.message.cast<O>(),
+                  Headers(),
+                ),
           ),
           interceptors: [
             <I extends Object, O extends Object>(next) {
@@ -170,9 +173,9 @@ void main() {
 
 class DelegatingProtocol implements Protocol {
   final Headers Function<I, O>(Spec<I, O>, Codec, CallOptions?)?
-      onRequestHeaders;
+  onRequestHeaders;
   final Future<StreamResponse<I, O>> Function<I, O>(StreamRequest<I, O>)?
-      onStream;
+  onStream;
   final Future<UnaryResponse<I, O>> Function<I, O>(UnaryRequest<I, O>)? onUnary;
   DelegatingProtocol({this.onUnary, this.onStream, this.onRequestHeaders});
 
@@ -231,15 +234,15 @@ class DelegatingProtocol implements Protocol {
 
 final class TestTransport extends ProtocolTransport {
   TestTransport({required Protocol protocol, List<Interceptor>? interceptors})
-      : super(
-          "https://test",
-          ProtoCodec(),
-          protocol,
-          (req) => throw UnimplementedError(),
-          interceptors ?? [],
-          null,
-          [],
-        );
+    : super(
+        "https://test",
+        ProtoCodec(),
+        protocol,
+        (req) => throw UnimplementedError(),
+        interceptors ?? [],
+        null,
+        [],
+      );
 }
 
 final class ClassInterceptor {

--- a/packages/tools/pubspec.yaml
+++ b/packages/tools/pubspec.yaml
@@ -10,7 +10,7 @@ executables:
   license_header:
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 resolution: workspace
 dependencies:
   path: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: connect_dart
 publish_to: none
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.7.0
 dev_dependencies:
   lints: ^4.0.0
 workspace:


### PR DESCRIPTION
This PR
* updates dart version to 3.7.0
* runs `dart format .`
* fixes a place where `_` was used as type parameter in `packages/connect/lib/src/protocol/serialization.dart`, which is no longer OK in 3.7.0